### PR TITLE
**Pull Request: Fix Regression - Restore Idle Notifications in Nudge System**

### DIFF
--- a/focus-nudge
+++ b/focus-nudge
@@ -236,9 +236,12 @@ main() {
     
     # Send appropriate notification
     if [[ "$status" == "inactive" ]]; then
-        # Don't send notifications when there's no active session
-        # Just log that we checked and found no active session
-        log_message "no active focus session found, no notification needed"
+        # Send idle notification to remind user to start focusing
+        if send_notification "Focus Reminder" "You're not focusing on any project. Time to get back to work?"; then
+            log_message "idle notification sent successfully"
+        else
+            log_message "error: failed to send idle notification"
+        fi
     elif [[ "$status" == "paused"* ]]; then
         IFS='|' read -r state project pause_notes <<< "$status"
         if [[ "$state" == "paused" ]]; then


### PR DESCRIPTION
This PR fixes a regression where idle notifications were silently removed during recent nudge system improvements. The fix restores gentle reminders to resume focus work while maintaining all recent enhancements.

> - Relates to #3
> - Relates to #10

### **Problem**
The nudge system was only sending notifications for active sessions and silently logging for inactive ones, removing the motivational reminders that help users remember to start focusing again.

### **Solution**
Restored idle notifications in the `focus-nudge` script by changing the "inactive" status case from logging-only back to sending user-facing reminders.

### **Code Changes**
```diff
- # Don't send notifications when there's no active session
- log_message "no active focus session found, no notification needed"
+ # Send idle notification to remind user to start focusing
+ if send_notification "Focus Reminder" "You're not focusing on any project. Time to get back to work?"; then
+     log_message "idle notification sent successfully"
+ else
+     log_message "error: failed to send idle notification"
+ fi
```

### **Current Behavior**
✅ **Active sessions**: "Focus Reminder - You're focusing on: [project] (Xm elapsed)"  
✅ **Paused sessions**: "Focus Paused - Session paused: [project] - [notes]"  
✅ **Idle state**: "Focus Reminder - You're not focusing on any project. Time to get back to work?"  

### **Testing**
- [x] Idle notifications working when no active session
- [x] Active session notifications working during focus
- [x] Paused session notifications working
- [x] Enhanced error handling and logging

### **Impact**
- **Restored**: Essential user motivation for idle state
- **Maintained**: All recent nudge system improvements
- **Enhanced**: Better error handling and debugging

**Files Modified**: `focus-nudge`