### PR TITLE
fix: bash-3.2 report crash, BSD sed t-label, wc -l test padding [#21]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,13 +131,16 @@ grep -rn "nudging_enabled\|pause_notes\|\bprojects\b\|focus describe\|nudge enab
 grep -rn '"Usage:' lib/ focus focus-nudge 2>/dev/null
 # Expected: no output
 
-# CONV-PORTABLE: only core/time.sh calls date(1), and nobody uses GNU-only
-# `sed -i`. Both skip comment lines, so the notes explaining the rule don't
-# trip the check that enforces it.
+# CONV-PORTABLE: only core/time.sh calls date(1), nobody uses GNU-only `sed -i`
+# or a `;`-terminated `t` label, and nobody uses `declare -A` — macOS ships
+# bash 3.2, which has no associative arrays; `focus report` had zero working
+# subcommands on macOS until this was enforced. All three skip comment lines,
+# so the notes explaining a rule don't trip the check that enforces it.
 grep -rn '^[^#]*\(date --date\|date -d \|date +%s\|date -Iseconds\)' \
      lib/ services/ focus focus-nudge env.sh 2>/dev/null
 grep -rn '^[^#]*sed -i' lib/ services/ core/ focus focus-nudge setup.sh 2>/dev/null
-# Expected: no output for both
+grep -rn '^[^#]*declare -A' lib/ services/ core/ focus focus-nudge 2>/dev/null
+# Expected: no output for all three
 ```
 
 If either returns output, stop, fix the violation, rerun before proceeding.

--- a/CONTRACTS/CONTRACT_INDEX.md
+++ b/CONTRACTS/CONTRACT_INDEX.md
@@ -1,6 +1,6 @@
 # CONTRACT_INDEX.md — refocus-shell
 
-> Line-range index into `MAIN.md` (637 lines). Lets an agent load a single
+> Line-range index into `MAIN.md` (658 lines). Lets an agent load a single
 > section or rule by range instead of the whole spec — context budget for small-
 > window models, precise citation for everyone else.
 >
@@ -21,17 +21,17 @@
 | INV    | Invariants                               | 124–179 |
 | NAME   | Naming contract                          | 181–201 |
 | ARCH   | Architecture & layering                  | 203–235 |
-| PORT   | Adapter surface (database.sh)            | 237–295 |
-| CORE   | Domain-helper surface (core/*.sh)        | 297–334 |
-| ENV    | Environment loader (env.sh)              | 336–353 |
-| CRON   | Nudge scheduling (cron.sh)               | 355–376 |
-| CMD    | Command surface (lib/)                   | 378–489 |
-| NUDGE  | Nudge payload (focus-nudge)              | 491–509 |
-| SM     | State machine                            | 511–530 |
-| CONV   | Conventions                              | 532–564 |
-| INT    | Install & shell integration              | 566–599 |
-| BUILD  | Build guardrails                         | 601–618 |
-| ACCEPT | Acceptance                               | 620–637 |
+| PORT   | Adapter surface (database.sh)            | 237–301 |
+| CORE   | Domain-helper surface (core/*.sh)        | 303–340 |
+| ENV    | Environment loader (env.sh)              | 342–359 |
+| CRON   | Nudge scheduling (cron.sh)               | 361–382 |
+| CMD    | Command surface (lib/)                   | 384–498 |
+| NUDGE  | Nudge payload (focus-nudge)              | 500–518 |
+| SM     | State machine                            | 520–539 |
+| CONV   | Conventions                              | 541–585 |
+| INT    | Install & shell integration              | 587–620 |
+| BUILD  | Build guardrails                         | 622–639 |
+| ACCEPT | Acceptance                               | 641–658 |
 
 ---
 
@@ -62,22 +62,22 @@
 
 | Code | Command | Lines |
 |---|---|---|
-| CMD-ON       | focus on [project] | 382–390 |
-| CMD-OFF      | focus off | 392–398 |
-| CMD-PAUSE    | focus pause | 400–402 |
-| CMD-CONTINUE | focus continue | 404–408 |
-| CMD-STATUS   | focus status | 410–413 |
-| CMD-PAST     | focus past <list\|add\|modify\|delete> | 415–439 |
-| CMD-REPORT   | focus report <today\|week\|month\|custom N> | 441–443 |
-| CMD-ENABLE   | focus enable | 445–447 |
-| CMD-DISABLE  | focus disable | 449–451 |
-| CMD-NUDGE    | focus nudge <status\|test> | 453–455 |
-| CMD-CONFIG   | focus config <show\|set\|unset> | 457–460 |
-| CMD-EXPORT   | focus export [basename] | 462–463 |
-| CMD-IMPORT   | focus import <file> | 465–469 |
-| CMD-INIT     | focus init | 471–472 |
-| CMD-RESET    | focus reset | 474–476 |
-| CMD-HELP     | focus help [cmd] | 478–489 |
+| CMD-ON       | focus on [project] | 388–396 |
+| CMD-OFF      | focus off | 398–404 |
+| CMD-PAUSE    | focus pause | 406–408 |
+| CMD-CONTINUE | focus continue | 410–414 |
+| CMD-STATUS   | focus status | 416–419 |
+| CMD-PAST     | focus past <list\|add\|modify\|delete> | 421–445 |
+| CMD-REPORT   | focus report <today\|week\|month\|custom N> | 447–452 |
+| CMD-ENABLE   | focus enable | 454–456 |
+| CMD-DISABLE  | focus disable | 458–460 |
+| CMD-NUDGE    | focus nudge <status\|test> | 462–464 |
+| CMD-CONFIG   | focus config <show\|set\|unset> | 466–469 |
+| CMD-EXPORT   | focus export [basename] | 471–472 |
+| CMD-IMPORT   | focus import <file> | 474–478 |
+| CMD-INIT     | focus init | 480–481 |
+| CMD-RESET    | focus reset | 483–485 |
+| CMD-HELP     | focus help [cmd] | 487–498 |
 
 ---
 
@@ -85,19 +85,19 @@
 
 | Code | Surface | Lines |
 |---|---|---|
-| PORT | database.sh — full intent API | 237–295 |
-| CORE | core/*.sh — time + text helpers | 297–334 |
-| CORE-TIME | core/time.sh — duration/time parsing, GNU-BSD split | 302–322 |
-| CORE-TEXT | core/text.sh — notes decode + block rendering | 324–334 |
-| ENV  | env.sh — loader + exports + precedence | 336–353 |
-| CRON | cron.sh — install/remove + entry format | 355–376 |
-| NUDGE | focus-nudge — the cron payload | 491–509 |
-| INT-INSTALL | setup.sh | 573–583 |
-| INT-DESKTOP | refocus.desktop | 585–588 |
-| INT-SHELL   | focus-function.sh | 590–599 |
+| PORT | database.sh — full intent API | 237–301 |
+| CORE | core/*.sh — time + text helpers | 303–340 |
+| CORE-TIME | core/time.sh — duration/time parsing, GNU-BSD split | 308–328 |
+| CORE-TEXT | core/text.sh — notes decode + block rendering | 330–340 |
+| ENV  | env.sh — loader + exports + precedence | 342–359 |
+| CRON | cron.sh — install/remove + entry format | 361–382 |
+| NUDGE | focus-nudge — the cron payload | 500–518 |
+| INT-INSTALL | setup.sh | 594–604 |
+| INT-DESKTOP | refocus.desktop | 606–609 |
+| INT-SHELL   | focus-function.sh | 611–620 |
 
 Note: `services/help.sh` and `services/editor.sh` have no surface section of
-their own — they are specified where they are used, at CMD-HELP (478–489) and
+their own — they are specified where they are used, at CMD-HELP (487–498) and
 CMD-OFF / CMD-PAST respectively.
 
 ---
@@ -114,32 +114,33 @@ by its bullet in [CONV] and referenced from the commands it governs.
 | ARCH-ROOT              | REFOCUS_ROOT via realpath(BASH_SOURCE) | 227 | ARCH |
 | ARCH-SOURCE            | handler source order | 232 | ARCH |
 | PORT-NOTES             | notes encode newlines on read | 278 | PORT |
-| CORE-DATE              | date(1) confined to core/time.sh | 315 | CORE-TIME |
-| CMD-OFF-RECOVERY       | off ignores focus_disabled | 396 | CMD-OFF |
-| CMD-PAST-ARGS          | optional leading project; don't eat --duration | 427 | CMD-PAST |
-| CMD-PAST-ID            | numeric id guard before the adapter | 433 | CMD-PAST |
-| CMD-PAST-NOOP          | a modify that changes nothing is exit 2 | 437 | CMD-PAST |
-| CMD-HELP-INTERCEPT     | wants_help runs before parsing and db_ensure | 484 | CMD-HELP |
-| NUDGE-HISTORY          | desktop-entry hint → logged in history | 505 | NUDGE |
-| SM-INVARIANT           | disabled ⇒ idle; active+disabled illegal | 520 | SM |
-| CONV-EXIT              | exit codes 0/1/2 | 534 | CONV |
-| CONV-YES               | destructive ops need literal "yes" | 536 | CONV |
-| CONV-REARM             | reset/import leave disabled | 538 | CONV |
-| CONV-IDEMPOTENT-ENABLE | enable-when-enabled is a no-op | 541 | CONV |
-| CONV-DURONLY           | duration-only rows have no timestamps | 544 | CONV |
-| CONV-HELP              | help is data; no inline usage strings | 548 | CONV |
-| CONV-ID                | session ids validated in the handler | 553 | CONV |
-| CONV-NOTES             | encode/decode notes across the read boundary | 556 | CONV |
-| CONV-PORTABLE          | GNU+BSD userland; no date(1), no sed -i | 559 | CONV |
-| CONV-ENVFILE           | ENV_FILE computed once in env.sh | 349 | ENV |
-| CRON-BIN               | payload path resolved at call time | 363 | CRON |
-| CRON-ENV               | entry embeds REFOCUS_ROOT + display env | 365 | CRON |
-| CRON-STRIP             | fixed-string crontab strip, live only | 369 | CRON |
-| CRON-INTERVAL          | validate 1–60 numeric | 373 | CRON |
-| BUILD-NO-REGEN         | no whole-file regen through escaping | 606 | BUILD |
-| BUILD-VERIFY           | run both test scripts after changes | 611 | BUILD |
-| BUILD-UTF8             | shellcheck under LC_ALL=C.UTF-8 | 614 | BUILD |
-| BUILD-SCOPE            | one concern per change | 616 | BUILD |
+| PORT-BASH32            | get_project_totals_in_range aggregates in SQL, not bash | 291 | PORT |
+| CORE-DATE              | date(1) confined to core/time.sh | 321 | CORE-TIME |
+| CMD-OFF-RECOVERY       | off ignores focus_disabled | 402 | CMD-OFF |
+| CMD-PAST-ARGS          | optional leading project; don't eat --duration | 433 | CMD-PAST |
+| CMD-PAST-ID            | numeric id guard before the adapter | 439 | CMD-PAST |
+| CMD-PAST-NOOP          | a modify that changes nothing is exit 2 | 443 | CMD-PAST |
+| CMD-HELP-INTERCEPT     | wants_help runs before parsing and db_ensure | 493 | CMD-HELP |
+| NUDGE-HISTORY          | desktop-entry hint → logged in history | 514 | NUDGE |
+| SM-INVARIANT           | disabled ⇒ idle; active+disabled illegal | 529 | SM |
+| CONV-EXIT              | exit codes 0/1/2 | 543 | CONV |
+| CONV-YES               | destructive ops need literal "yes" | 545 | CONV |
+| CONV-REARM             | reset/import leave disabled | 547 | CONV |
+| CONV-IDEMPOTENT-ENABLE | enable-when-enabled is a no-op | 550 | CONV |
+| CONV-DURONLY           | duration-only rows have no timestamps | 553 | CONV |
+| CONV-HELP              | help is data; no inline usage strings | 557 | CONV |
+| CONV-ID                | session ids validated in the handler | 562 | CONV |
+| CONV-NOTES             | encode/decode notes across the read boundary | 565 | CONV |
+| CONV-PORTABLE          | GNU+BSD+bash-3.2; no date(1)/sed -i/sed t;/declare -A | 568 | CONV |
+| CONV-ENVFILE           | ENV_FILE computed once in env.sh | 355 | ENV |
+| CRON-BIN               | payload path resolved at call time | 369 | CRON |
+| CRON-ENV               | entry embeds REFOCUS_ROOT + display env | 371 | CRON |
+| CRON-STRIP             | fixed-string crontab strip, live only | 375 | CRON |
+| CRON-INTERVAL          | validate 1–60 numeric | 379 | CRON |
+| BUILD-NO-REGEN         | no whole-file regen through escaping | 627 | BUILD |
+| BUILD-VERIFY           | run both test scripts after changes | 632 | BUILD |
+| BUILD-UTF8             | shellcheck under LC_ALL=C.UTF-8 | 635 | BUILD |
+| BUILD-SCOPE            | one concern per change | 637 | BUILD |
 
 ---
 
@@ -147,7 +148,7 @@ by its bullet in [CONV] and referenced from the commands it governs.
 
 - Rebuilding a single component → load its surface row from *Component surfaces*
   plus every `INV-*` (124–179) and `NAME` (181–201). The invariants bind all of them.
-- Implementing one command → load its `CMD-*` row + `PORT` (237–295) + `CONV` (532–564).
+- Implementing one command → load its `CMD-*` row + `PORT` (237–301) + `CONV` (541–585).
 - Resolving an ambiguity → load the relevant rule's line ± its parent section, and
   decide by the WHY, never by local convenience (READ, 9–37).
-- Checking your work → `ACCEPT` (620–637).
+- Checking your work → `ACCEPT` (641–658).

--- a/CONTRACTS/MAIN.md
+++ b/CONTRACTS/MAIN.md
@@ -285,6 +285,12 @@ it (CONV-NOTES). The JSON and `.dump` exports are untouched — both formats
 carry newlines correctly on their own.
 
 **Serialization (db_*, storage):**
+- `get_project_totals_in_range <start> <end>` → `project|duration_seconds|session_count`
+  rows, one per project, `GROUP BY project` ordered by duration descending. Same
+  WHERE clause as `list_sessions_in_range` on purpose — the breakdown must count
+  exactly the sessions the raw listing shows. PORT-BASH32: this exists so `focus
+  report` never needs a bash associative array — macOS ships bash 3.2, which
+  has none, and `declare -A` there is not a warning, it's a hard abort.
 - `db_dump_sql` → `.dump` to stdout. `db_load_sql <file>` → restore.
 - `db_export_state_json` → single JSON object. `db_export_sessions_json` → array.
 - `db_import_session_row <7 fields>` — verbatim insert, NULLs preserved.
@@ -439,8 +445,11 @@ Each handler: source env + deps, `db_ensure`, then the logic below.
 - `delete <id>` — confirm, `delete_session`.
 
 ### CMD-REPORT · `focus report <today|week|month|custom N>`
-- compute range, `list_sessions_in_range`, print total + per-project + per-session.
-  `custom` requires numeric N (exit 2). Facts only, no score.
+- compute range, `list_sessions_in_range` for the total and per-session listing,
+  `get_project_totals_in_range` for the per-project breakdown (PORT-BASH32 —
+  never aggregate per-project totals in bash; that means `declare -A`, and
+  `focus report` must run on bash 3.2). `custom` requires numeric N (exit 2).
+  Facts only, no score.
 
 ### CMD-ENABLE · `focus enable`
 - already enabled (`! is_focus_disabled`) → say so, exit 0, touch nothing
@@ -556,9 +565,21 @@ active          1 0 0      paused          0 1 0
 - CONV-NOTES: notes may contain newlines; session reads may not (PORT-NOTES).
   Encode in the adapter, decode with `notes_decode`, render with `notes_block`.
   Never print a note straight from a read.
-- CONV-PORTABLE: the tool targets GNU and BSD userland. `date(1)` is confined to
-  `core/time.sh` (CORE-DATE) and `sed -i` is banned outright — GNU takes a bare
-  `-i`, BSD demands `-i ''`. Write a sibling temp file and rename.
+- CONV-PORTABLE: the tool targets GNU and BSD userland, **and bash 3.2** — macOS
+  ships 3.2 as `/bin/bash` (GPLv3; Apple will not move), and the shebang is
+  `#!/usr/bin/env bash`, so nothing forces a newer one onto PATH. Three concrete
+  bans, each cost a real bug on macOS before it was named here:
+  - `date(1)` is confined to `core/time.sh` (CORE-DATE).
+  - `sed -i` is banned outright — GNU takes a bare `-i`, BSD demands `-i ''`.
+    Write a sibling temp file and rename.
+  - A `t` label in a multi-command `sed` expression must be its own `-e`
+    clause. BSD reads a `;`-terminated label as part of the label name and
+    errors "undefined label"; `sed 's/a/b/;t;s/c/d/'` only works on GNU.
+  - **`declare -A` / associative arrays are banned outright** — bash 3.2 has
+    none, full stop, and the failure is `declare: -A: invalid option`, not a
+    warning. Aggregate in SQL instead (PORT-BASH32) — this is not a style
+    preference, `focus report` had zero working subcommands on macOS until it
+    moved the per-project breakdown into `get_project_totals_in_range`.
 - (CONV-ENVFILE lives in [ENV]; CRON-STRIP / CRON-INTERVAL live in [CRON].)
 
 ---

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -18,8 +18,11 @@ _show() {
     echo ""
     if [[ -f "$ENV_FILE" && -s "$ENV_FILE" ]]; then
         echo "Overrides ($ENV_FILE):"
-        # Strip REFOCUS_ prefix for readability
-        sed 's/^REFOCUS_/  /;t;s/^/  /' "$ENV_FILE"
+        # Strip REFOCUS_ prefix for readability. Split into -e clauses: BSD sed
+        # requires a `t` label to end at a newline, and reads a `;`-terminated
+        # label as part of the label name, so `t;s/^/  /` errors as an
+        # "undefined label" on macOS even though GNU sed accepts it inline.
+        sed -e 's/^REFOCUS_/  /' -e t -e 's/^/  /' "$ENV_FILE"
     else
         echo "(no overrides — $ENV_FILE)"
     fi

--- a/lib/report.sh
+++ b/lib/report.sh
@@ -18,29 +18,24 @@ _report() {
     echo "Period: $(ts_format "$start" "$DATE_FORMAT") → $(ts_format "$end" "$DATE_FORMAT")"
     echo ""
 
+    # No associative array: macOS ships bash 3.2 (no `declare -A` at all), so
+    # the per-project breakdown is aggregated in SQL (get_project_totals_in_range)
+    # instead. This loop only sums scalars, which every bash version supports.
     local total=0 sessions=0
-    # The =() initialisers are load-bearing: a bare `declare -A x` leaves the
-    # array unset, so ${#x[@]} on a period with no sessions trips `set -u` and
-    # aborted the whole report.
-    declare -A proj_dur=() proj_cnt=()
-
     while IFS='|' read -r id project start_t end_t dur notes duration_only session_date; do
         total=$(( total + dur ))
         sessions=$(( sessions + 1 ))
-        proj_dur[$project]=$(( ${proj_dur[$project]:-0} + dur ))
-        proj_cnt[$project]=$(( ${proj_cnt[$project]:-0} + 1 ))
     done < <(list_sessions_in_range "$start" "$end")
 
     echo "Total: $(fmt_duration $total) across $sessions session(s)"
     echo ""
 
-    if [[ ${#proj_dur[@]} -gt 0 ]]; then
-        echo "Projects:"
-        for p in "${!proj_dur[@]}"; do
-            printf "  %-24s %s (%d session(s))\n" "$p" "$(fmt_duration "${proj_dur[$p]}")" "${proj_cnt[$p]}"
-        done
-        echo ""
-    fi
+    local have_projects=0
+    while IFS='|' read -r p pdur pcnt; do
+        [[ $have_projects -eq 0 ]] && { echo "Projects:"; have_projects=1; }
+        printf "  %-24s %s (%d session(s))\n" "$p" "$(fmt_duration "$pdur")" "$pcnt"
+    done < <(get_project_totals_in_range "$start" "$end")
+    [[ $have_projects -eq 1 ]] && echo ""
 
     echo "Sessions:"
     while IFS='|' read -r id project start_t end_t dur notes duration_only session_date; do

--- a/services/database.sh
+++ b/services/database.sh
@@ -199,6 +199,26 @@ list_sessions_in_range() {
             ORDER BY COALESCE(end_time, session_date) DESC;"
 }
 
+get_project_totals_in_range() {
+    # <start> <end> -> project|duration_seconds|session_count, one row per
+    # project, ordered by duration_seconds descending.
+    #
+    # Same WHERE clause as list_sessions_in_range on purpose: report's
+    # per-project breakdown must count exactly the sessions the raw listing
+    # shows. Aggregating here rather than in bash means `focus report` has no
+    # associative-array dependency — macOS ships bash 3.2, which has none.
+    local start="$1" end="$2"
+    _query "SELECT project, SUM(duration_seconds), COUNT(*)
+            FROM sessions
+            WHERE (
+                (duration_only=0 AND end_time >= '$(_q "$start")' AND end_time <= '$(_q "$end")')
+                OR
+                (duration_only=1 AND session_date >= date('$(_q "$start")') AND session_date <= date('$(_q "$end")'))
+            )
+            GROUP BY project
+            ORDER BY SUM(duration_seconds) DESC;"
+}
+
 get_session() {
     local id="$1"
     _query "SELECT id, project, COALESCE(start_time,''), COALESCE(end_time,''),

--- a/tests/state-matrix.sh
+++ b/tests/state-matrix.sh
@@ -188,7 +188,7 @@ nid=$(sqlite3 "$REFOCUS_DB_PATH" "SELECT id FROM sessions WHERE project='note/mu
 chk "note keeps both lines" "first line
 second line" "$(sqlite3 "$REFOCUS_DB_PATH" "SELECT notes FROM sessions WHERE id=$nid;")"
 chk "encoded read stays one row" "1" \
-    "$(bash -c 'source env.sh; source services/database.sh; get_session '"$nid"' | wc -l')"
+    "$(bash -c 'source env.sh; source services/database.sh; get_session '"$nid"' | wc -l' | tr -d ' ')"
 chk "encoded read stays 8 fields" "8" \
     "$(bash -c 'source env.sh; source services/database.sh; get_session '"$nid"' | awk -F"|" "{print NF}"')"
 chk "past list renders both lines" "0" \
@@ -205,6 +205,34 @@ chk "--notes preserves duration" "$dur_before"  "$(sqlite3 "$REFOCUS_DB_PATH" "S
 # period with no sessions exited 1.
 echo "── report: empty period ──"
 ./focus report custom 1 >/dev/null 2>&1; chk "report on empty period rc=0" "0" "$?"
+
+# ── report: bash-3.2 compat (macOS ships bash 3.2, no associative arrays) ────
+# report.sh previously kept per-project totals in `declare -A`, which macOS's
+# shipped /bin/bash cannot parse at all -- every `focus report` call aborted
+# on macOS. Aggregation now happens in SQL (get_project_totals_in_range);
+# this checks the construct is gone and the breakdown is still correct.
+echo "── report: bash-3.2 compat ──"
+if grep -q '^[^#]*declare -A' lib/report.sh; then assoc_array_found=yes; else assoc_array_found=no; fi
+chk "report.sh has no associative array" "no" "$assoc_array_found"
+printf 'r1\n' | ./focus past add rep/x 2026/06/12-09:00 2026/06/12-10:00 >/dev/null 2>&1
+printf 'r2\n' | ./focus past add rep/x 2026/06/12-10:00 2026/06/12-12:00 >/dev/null 2>&1
+printf 'r3\n' | ./focus past add rep/y 2026/06/12-13:00 2026/06/12-13:30 >/dev/null 2>&1
+out=$(./focus report custom 90000 2>&1)
+chk "report: multi-session project total" "0" \
+    "$([[ "$out" == *"rep/x"*"3h 0m"*"2 session"* ]]; echo $?)"
+chk "report: single-session project total" "0" \
+    "$([[ "$out" == *"rep/y"*"30m"*"1 session"* ]]; echo $?)"
+
+# ── config show: BSD sed t-label ─────────────────────────────────────────────
+# BSD sed reads a `;`-terminated `t` label as part of the label name and
+# errors "undefined label"; GNU accepts it inline. Split into -e clauses.
+# This only exercises the GNU path here, but guards against reintroducing the
+# single-expression form.
+echo "── config show ──"
+./focus config set NUDGE_INTERVAL 11 >/dev/null 2>&1
+out=$(./focus config show 2>&1); rc=$?
+chk "config show rc=0 with overrides" "0" "$rc"
+chk "config show renders override"   "0" "$([[ "$out" == *"NUDGE_INTERVAL=11"* ]]; echo $?)"
 
 # ── result ───────────────────────────────────────────────────────────────────
 echo


### PR DESCRIPTION
Ground-truth testing on real BSD userland (macOS 26, bash 3.2) found three bugs the earlier fixes for #21 missed:

- lib/report.sh — `declare -A` is bash 4+ only; macOS ships bash 3.2 (GPLv3, will not move) as /bin/bash with nothing in the repo forcing a newer one onto PATH. Every `focus report` subcommand aborted with `declare: -A: invalid option`. Fixed by moving the per-project breakdown into SQL: services/database.sh gains get_project_totals_in_range, GROUP BY project with the same WHERE clause as list_sessions_in_range so the breakdown counts exactly what the raw listing shows. report.sh now does no aggregation of its own — just two SELECTs and formatting — which closes the bash-version dependency as a class, not just this instance (CONTRACTS/MAIN.md: PORT-BASH32, CONV-PORTABLE).

- lib/config.sh:22 — a second, unrelated sed call in the same file the sed -i fix touched. BSD sed reads a `;`-terminated `t` label as part of the label name and errors "undefined label"; GNU accepts it inline. `focus config show` failed whenever .env had any overrides — the whole point of that command. Split into -e clauses, portable on both.

- tests/state-matrix.sh:191 — a bug in a test added this session: asserting against BSD `wc -l`, which right-pads its count; GNU doesn't. The product was correct, the assertion wasn't portable. `| tr -d ' '`.

Added regression tests for both product fixes (report.sh has no associative array + a functional multi-project total check; config show renders overrides). The report.sh test was verified to fail before the fix by temporarily reintroducing `declare -A` and confirming state-matrix catches it.

Also confirmed by the same report and requiring no further change: focus-nudge's date(1) call (fixed last commit) was worse than known — it failed with exit 0 on old BSD builds and silently reported 56 years of focus from an empty $start_ts; the offset-colon strip round-trips exactly; 14:30 parsing works; relative English times correctly refuse with a clear coreutils hint since BSD date cannot parse them at all.

tests/audit.sh: 0. tests/state-matrix.sh: 50/50 (was 45).
tests/time-portability.sh: 20/20.