### PR TITLE
Chore/bugfixing

### DIFF
--- a/CONTRACTS/CONTRACT_INDEX.md
+++ b/CONTRACTS/CONTRACT_INDEX.md
@@ -1,6 +1,6 @@
 # CONTRACT_INDEX.md — refocus-shell
 
-> Line-range index into `MAIN.md` (668 lines). Lets an agent load a single
+> Line-range index into `MAIN.md` (676 lines). Lets an agent load a single
 > section or rule by range instead of the whole spec — context budget for small-
 > window models, precise citation for everyone else.
 >
@@ -25,13 +25,13 @@
 | CORE   | Domain-helper surface (core/*.sh)        | 313–350 |
 | ENV    | Environment loader (env.sh)              | 352–369 |
 | CRON   | Nudge scheduling (cron.sh)               | 371–392 |
-| CMD    | Command surface (lib/)                   | 394–508 |
-| NUDGE  | Nudge payload (focus-nudge)              | 510–528 |
-| SM     | State machine                            | 530–549 |
-| CONV   | Conventions                              | 551–595 |
-| INT    | Install & shell integration              | 597–630 |
-| BUILD  | Build guardrails                         | 632–649 |
-| ACCEPT | Acceptance                               | 651–668 |
+| CMD    | Command surface (lib/)                   | 394–516 |
+| NUDGE  | Nudge payload (focus-nudge)              | 518–536 |
+| SM     | State machine                            | 538–557 |
+| CONV   | Conventions                              | 559–603 |
+| INT    | Install & shell integration              | 605–638 |
+| BUILD  | Build guardrails                         | 640–657 |
+| ACCEPT | Acceptance                               | 659–676 |
 
 ---
 
@@ -72,12 +72,12 @@
 | CMD-ENABLE   | focus enable | 464–466 |
 | CMD-DISABLE  | focus disable | 468–470 |
 | CMD-NUDGE    | focus nudge <status\|test> | 472–474 |
-| CMD-CONFIG   | focus config <show\|set\|unset> | 476–479 |
-| CMD-EXPORT   | focus export [basename] | 481–482 |
-| CMD-IMPORT   | focus import <file> | 484–488 |
-| CMD-INIT     | focus init | 490–491 |
-| CMD-RESET    | focus reset | 493–495 |
-| CMD-HELP     | focus help [cmd] | 497–508 |
+| CMD-CONFIG   | focus config <show\|set\|unset> | 476–487 |
+| CMD-EXPORT   | focus export [basename] | 489–490 |
+| CMD-IMPORT   | focus import <file> | 492–496 |
+| CMD-INIT     | focus init | 498–499 |
+| CMD-RESET    | focus reset | 501–503 |
+| CMD-HELP     | focus help [cmd] | 505–516 |
 
 ---
 
@@ -91,13 +91,13 @@
 | CORE-TEXT | core/text.sh — notes decode + block rendering | 340–350 |
 | ENV  | env.sh — loader + exports + precedence | 352–369 |
 | CRON | cron.sh — install/remove + entry format | 371–392 |
-| NUDGE | focus-nudge — the cron payload | 510–528 |
-| INT-INSTALL | setup.sh | 604–614 |
-| INT-DESKTOP | refocus.desktop | 616–619 |
-| INT-SHELL   | focus-function.sh | 621–630 |
+| NUDGE | focus-nudge — the cron payload | 518–536 |
+| INT-INSTALL | setup.sh | 612–622 |
+| INT-DESKTOP | refocus.desktop | 624–627 |
+| INT-SHELL   | focus-function.sh | 629–638 |
 
 Note: `services/help.sh` and `services/editor.sh` have no surface section of
-their own — they are specified where they are used, at CMD-HELP (497–508) and
+their own — they are specified where they are used, at CMD-HELP (505–516) and
 CMD-OFF / CMD-PAST respectively.
 
 ---
@@ -121,27 +121,27 @@ by its bullet in [CONV] and referenced from the commands it governs.
 | CMD-PAST-ARGS          | optional leading project; don't eat --duration | 443 | CMD-PAST |
 | CMD-PAST-ID            | numeric id guard before the adapter | 449 | CMD-PAST |
 | CMD-PAST-NOOP          | a modify that changes nothing is exit 2 | 453 | CMD-PAST |
-| CMD-HELP-INTERCEPT     | wants_help runs before parsing and db_ensure | 503 | CMD-HELP |
-| NUDGE-HISTORY          | desktop-entry hint → logged in history | 524 | NUDGE |
-| SM-INVARIANT           | disabled ⇒ idle; active+disabled illegal | 539 | SM |
-| CONV-EXIT              | exit codes 0/1/2 | 553 | CONV |
-| CONV-YES               | destructive ops need literal "yes" | 555 | CONV |
-| CONV-REARM             | reset/import leave disabled | 557 | CONV |
-| CONV-IDEMPOTENT-ENABLE | enable-when-enabled is a no-op | 560 | CONV |
-| CONV-DURONLY           | duration-only rows have no timestamps | 563 | CONV |
-| CONV-HELP              | help is data; no inline usage strings | 567 | CONV |
-| CONV-ID                | session ids validated in the handler | 572 | CONV |
-| CONV-NOTES             | encode/decode notes across the read boundary | 575 | CONV |
-| CONV-PORTABLE          | GNU+BSD+bash-3.2; no date(1)/sed -i/sed t;/declare -A | 578 | CONV |
+| CMD-HELP-INTERCEPT     | wants_help runs before parsing and db_ensure | 511 | CMD-HELP |
+| NUDGE-HISTORY          | desktop-entry hint → logged in history | 532 | NUDGE |
+| SM-INVARIANT           | disabled ⇒ idle; active+disabled illegal | 547 | SM |
+| CONV-EXIT              | exit codes 0/1/2 | 561 | CONV |
+| CONV-YES               | destructive ops need literal "yes" | 563 | CONV |
+| CONV-REARM             | reset/import leave disabled | 565 | CONV |
+| CONV-IDEMPOTENT-ENABLE | enable-when-enabled is a no-op | 568 | CONV |
+| CONV-DURONLY           | duration-only rows have no timestamps | 571 | CONV |
+| CONV-HELP              | help is data; no inline usage strings | 575 | CONV |
+| CONV-ID                | session ids validated in the handler | 580 | CONV |
+| CONV-NOTES             | encode/decode notes across the read boundary | 583 | CONV |
+| CONV-PORTABLE          | GNU+BSD+bash-3.2; no date(1)/sed -i/sed t;/declare -A | 586 | CONV |
 | CONV-ENVFILE           | ENV_FILE computed once in env.sh | 365 | ENV |
 | CRON-BIN               | payload path resolved at call time | 379 | CRON |
 | CRON-ENV               | entry embeds REFOCUS_ROOT + display env | 381 | CRON |
 | CRON-STRIP             | fixed-string crontab strip, live only | 385 | CRON |
 | CRON-INTERVAL          | validate 1–60 numeric | 389 | CRON |
-| BUILD-NO-REGEN         | no whole-file regen through escaping | 637 | BUILD |
-| BUILD-VERIFY           | run both test scripts after changes | 642 | BUILD |
-| BUILD-UTF8             | shellcheck under LC_ALL=C.UTF-8 | 645 | BUILD |
-| BUILD-SCOPE            | one concern per change | 647 | BUILD |
+| BUILD-NO-REGEN         | no whole-file regen through escaping | 645 | BUILD |
+| BUILD-VERIFY           | run both test scripts after changes | 650 | BUILD |
+| BUILD-UTF8             | shellcheck under LC_ALL=C.UTF-8 | 653 | BUILD |
+| BUILD-SCOPE            | one concern per change | 655 | BUILD |
 
 ---
 
@@ -149,7 +149,7 @@ by its bullet in [CONV] and referenced from the commands it governs.
 
 - Rebuilding a single component → load its surface row from *Component surfaces*
   plus every `INV-*` (124–179) and `NAME` (181–201). The invariants bind all of them.
-- Implementing one command → load its `CMD-*` row + `PORT` (237–311) + `CONV` (551–595).
+- Implementing one command → load its `CMD-*` row + `PORT` (237–311) + `CONV` (559–603).
 - Resolving an ambiguity → load the relevant rule's line ± its parent section, and
   decide by the WHY, never by local convenience (READ, 9–37).
-- Checking your work → `ACCEPT` (651–668).
+- Checking your work → `ACCEPT` (659–676).

--- a/CONTRACTS/CONTRACT_INDEX.md
+++ b/CONTRACTS/CONTRACT_INDEX.md
@@ -1,6 +1,6 @@
 # CONTRACT_INDEX.md — refocus-shell
 
-> Line-range index into `MAIN.md` (658 lines). Lets an agent load a single
+> Line-range index into `MAIN.md` (668 lines). Lets an agent load a single
 > section or rule by range instead of the whole spec — context budget for small-
 > window models, precise citation for everyone else.
 >
@@ -21,17 +21,17 @@
 | INV    | Invariants                               | 124–179 |
 | NAME   | Naming contract                          | 181–201 |
 | ARCH   | Architecture & layering                  | 203–235 |
-| PORT   | Adapter surface (database.sh)            | 237–301 |
-| CORE   | Domain-helper surface (core/*.sh)        | 303–340 |
-| ENV    | Environment loader (env.sh)              | 342–359 |
-| CRON   | Nudge scheduling (cron.sh)               | 361–382 |
-| CMD    | Command surface (lib/)                   | 384–498 |
-| NUDGE  | Nudge payload (focus-nudge)              | 500–518 |
-| SM     | State machine                            | 520–539 |
-| CONV   | Conventions                              | 541–585 |
-| INT    | Install & shell integration              | 587–620 |
-| BUILD  | Build guardrails                         | 622–639 |
-| ACCEPT | Acceptance                               | 641–658 |
+| PORT   | Adapter surface (database.sh)            | 237–311 |
+| CORE   | Domain-helper surface (core/*.sh)        | 313–350 |
+| ENV    | Environment loader (env.sh)              | 352–369 |
+| CRON   | Nudge scheduling (cron.sh)               | 371–392 |
+| CMD    | Command surface (lib/)                   | 394–508 |
+| NUDGE  | Nudge payload (focus-nudge)              | 510–528 |
+| SM     | State machine                            | 530–549 |
+| CONV   | Conventions                              | 551–595 |
+| INT    | Install & shell integration              | 597–630 |
+| BUILD  | Build guardrails                         | 632–649 |
+| ACCEPT | Acceptance                               | 651–668 |
 
 ---
 
@@ -62,22 +62,22 @@
 
 | Code | Command | Lines |
 |---|---|---|
-| CMD-ON       | focus on [project] | 388–396 |
-| CMD-OFF      | focus off | 398–404 |
-| CMD-PAUSE    | focus pause | 406–408 |
-| CMD-CONTINUE | focus continue | 410–414 |
-| CMD-STATUS   | focus status | 416–419 |
-| CMD-PAST     | focus past <list\|add\|modify\|delete> | 421–445 |
-| CMD-REPORT   | focus report <today\|week\|month\|custom N> | 447–452 |
-| CMD-ENABLE   | focus enable | 454–456 |
-| CMD-DISABLE  | focus disable | 458–460 |
-| CMD-NUDGE    | focus nudge <status\|test> | 462–464 |
-| CMD-CONFIG   | focus config <show\|set\|unset> | 466–469 |
-| CMD-EXPORT   | focus export [basename] | 471–472 |
-| CMD-IMPORT   | focus import <file> | 474–478 |
-| CMD-INIT     | focus init | 480–481 |
-| CMD-RESET    | focus reset | 483–485 |
-| CMD-HELP     | focus help [cmd] | 487–498 |
+| CMD-ON       | focus on [project] | 398–406 |
+| CMD-OFF      | focus off | 408–414 |
+| CMD-PAUSE    | focus pause | 416–418 |
+| CMD-CONTINUE | focus continue | 420–424 |
+| CMD-STATUS   | focus status | 426–429 |
+| CMD-PAST     | focus past <list\|add\|modify\|delete> | 431–455 |
+| CMD-REPORT   | focus report <today\|week\|month\|custom N> | 457–462 |
+| CMD-ENABLE   | focus enable | 464–466 |
+| CMD-DISABLE  | focus disable | 468–470 |
+| CMD-NUDGE    | focus nudge <status\|test> | 472–474 |
+| CMD-CONFIG   | focus config <show\|set\|unset> | 476–479 |
+| CMD-EXPORT   | focus export [basename] | 481–482 |
+| CMD-IMPORT   | focus import <file> | 484–488 |
+| CMD-INIT     | focus init | 490–491 |
+| CMD-RESET    | focus reset | 493–495 |
+| CMD-HELP     | focus help [cmd] | 497–508 |
 
 ---
 
@@ -85,19 +85,19 @@
 
 | Code | Surface | Lines |
 |---|---|---|
-| PORT | database.sh — full intent API | 237–301 |
-| CORE | core/*.sh — time + text helpers | 303–340 |
-| CORE-TIME | core/time.sh — duration/time parsing, GNU-BSD split | 308–328 |
-| CORE-TEXT | core/text.sh — notes decode + block rendering | 330–340 |
-| ENV  | env.sh — loader + exports + precedence | 342–359 |
-| CRON | cron.sh — install/remove + entry format | 361–382 |
-| NUDGE | focus-nudge — the cron payload | 500–518 |
-| INT-INSTALL | setup.sh | 594–604 |
-| INT-DESKTOP | refocus.desktop | 606–609 |
-| INT-SHELL   | focus-function.sh | 611–620 |
+| PORT | database.sh — full intent API | 237–311 |
+| CORE | core/*.sh — time + text helpers | 313–350 |
+| CORE-TIME | core/time.sh — duration/time parsing, GNU-BSD split | 318–338 |
+| CORE-TEXT | core/text.sh — notes decode + block rendering | 340–350 |
+| ENV  | env.sh — loader + exports + precedence | 352–369 |
+| CRON | cron.sh — install/remove + entry format | 371–392 |
+| NUDGE | focus-nudge — the cron payload | 510–528 |
+| INT-INSTALL | setup.sh | 604–614 |
+| INT-DESKTOP | refocus.desktop | 616–619 |
+| INT-SHELL   | focus-function.sh | 621–630 |
 
 Note: `services/help.sh` and `services/editor.sh` have no surface section of
-their own — they are specified where they are used, at CMD-HELP (487–498) and
+their own — they are specified where they are used, at CMD-HELP (497–508) and
 CMD-OFF / CMD-PAST respectively.
 
 ---
@@ -113,34 +113,35 @@ by its bullet in [CONV] and referenced from the commands it governs.
 | ARCH-ROUTABLE          | dispatcher routes only to lib/ | 223 | ARCH |
 | ARCH-ROOT              | REFOCUS_ROOT via realpath(BASH_SOURCE) | 227 | ARCH |
 | ARCH-SOURCE            | handler source order | 232 | ARCH |
-| PORT-NOTES             | notes encode newlines on read | 278 | PORT |
-| PORT-BASH32            | get_project_totals_in_range aggregates in SQL, not bash | 291 | PORT |
-| CORE-DATE              | date(1) confined to core/time.sh | 321 | CORE-TIME |
-| CMD-OFF-RECOVERY       | off ignores focus_disabled | 402 | CMD-OFF |
-| CMD-PAST-ARGS          | optional leading project; don't eat --duration | 433 | CMD-PAST |
-| CMD-PAST-ID            | numeric id guard before the adapter | 439 | CMD-PAST |
-| CMD-PAST-NOOP          | a modify that changes nothing is exit 2 | 443 | CMD-PAST |
-| CMD-HELP-INTERCEPT     | wants_help runs before parsing and db_ensure | 493 | CMD-HELP |
-| NUDGE-HISTORY          | desktop-entry hint → logged in history | 514 | NUDGE |
-| SM-INVARIANT           | disabled ⇒ idle; active+disabled illegal | 529 | SM |
-| CONV-EXIT              | exit codes 0/1/2 | 543 | CONV |
-| CONV-YES               | destructive ops need literal "yes" | 545 | CONV |
-| CONV-REARM             | reset/import leave disabled | 547 | CONV |
-| CONV-IDEMPOTENT-ENABLE | enable-when-enabled is a no-op | 550 | CONV |
-| CONV-DURONLY           | duration-only rows have no timestamps | 553 | CONV |
-| CONV-HELP              | help is data; no inline usage strings | 557 | CONV |
-| CONV-ID                | session ids validated in the handler | 562 | CONV |
-| CONV-NOTES             | encode/decode notes across the read boundary | 565 | CONV |
-| CONV-PORTABLE          | GNU+BSD+bash-3.2; no date(1)/sed -i/sed t;/declare -A | 568 | CONV |
-| CONV-ENVFILE           | ENV_FILE computed once in env.sh | 355 | ENV |
-| CRON-BIN               | payload path resolved at call time | 369 | CRON |
-| CRON-ENV               | entry embeds REFOCUS_ROOT + display env | 371 | CRON |
-| CRON-STRIP             | fixed-string crontab strip, live only | 375 | CRON |
-| CRON-INTERVAL          | validate 1–60 numeric | 379 | CRON |
-| BUILD-NO-REGEN         | no whole-file regen through escaping | 627 | BUILD |
-| BUILD-VERIFY           | run both test scripts after changes | 632 | BUILD |
-| BUILD-UTF8             | shellcheck under LC_ALL=C.UTF-8 | 635 | BUILD |
-| BUILD-SCOPE            | one concern per change | 637 | BUILD |
+| PORT-PROJVALID         | project name validated before every DB write | 245 | PORT |
+| PORT-NOTES             | notes encode newlines on read | 288 | PORT |
+| PORT-BASH32            | get_project_totals_in_range aggregates in SQL, not bash | 301 | PORT |
+| CORE-DATE              | date(1) confined to core/time.sh | 331 | CORE-TIME |
+| CMD-OFF-RECOVERY       | off ignores focus_disabled | 412 | CMD-OFF |
+| CMD-PAST-ARGS          | optional leading project; don't eat --duration | 443 | CMD-PAST |
+| CMD-PAST-ID            | numeric id guard before the adapter | 449 | CMD-PAST |
+| CMD-PAST-NOOP          | a modify that changes nothing is exit 2 | 453 | CMD-PAST |
+| CMD-HELP-INTERCEPT     | wants_help runs before parsing and db_ensure | 503 | CMD-HELP |
+| NUDGE-HISTORY          | desktop-entry hint → logged in history | 524 | NUDGE |
+| SM-INVARIANT           | disabled ⇒ idle; active+disabled illegal | 539 | SM |
+| CONV-EXIT              | exit codes 0/1/2 | 553 | CONV |
+| CONV-YES               | destructive ops need literal "yes" | 555 | CONV |
+| CONV-REARM             | reset/import leave disabled | 557 | CONV |
+| CONV-IDEMPOTENT-ENABLE | enable-when-enabled is a no-op | 560 | CONV |
+| CONV-DURONLY           | duration-only rows have no timestamps | 563 | CONV |
+| CONV-HELP              | help is data; no inline usage strings | 567 | CONV |
+| CONV-ID                | session ids validated in the handler | 572 | CONV |
+| CONV-NOTES             | encode/decode notes across the read boundary | 575 | CONV |
+| CONV-PORTABLE          | GNU+BSD+bash-3.2; no date(1)/sed -i/sed t;/declare -A | 578 | CONV |
+| CONV-ENVFILE           | ENV_FILE computed once in env.sh | 365 | ENV |
+| CRON-BIN               | payload path resolved at call time | 379 | CRON |
+| CRON-ENV               | entry embeds REFOCUS_ROOT + display env | 381 | CRON |
+| CRON-STRIP             | fixed-string crontab strip, live only | 385 | CRON |
+| CRON-INTERVAL          | validate 1–60 numeric | 389 | CRON |
+| BUILD-NO-REGEN         | no whole-file regen through escaping | 637 | BUILD |
+| BUILD-VERIFY           | run both test scripts after changes | 642 | BUILD |
+| BUILD-UTF8             | shellcheck under LC_ALL=C.UTF-8 | 645 | BUILD |
+| BUILD-SCOPE            | one concern per change | 647 | BUILD |
 
 ---
 
@@ -148,7 +149,7 @@ by its bullet in [CONV] and referenced from the commands it governs.
 
 - Rebuilding a single component → load its surface row from *Component surfaces*
   plus every `INV-*` (124–179) and `NAME` (181–201). The invariants bind all of them.
-- Implementing one command → load its `CMD-*` row + `PORT` (237–301) + `CONV` (541–585).
+- Implementing one command → load its `CMD-*` row + `PORT` (237–311) + `CONV` (551–595).
 - Resolving an ambiguity → load the relevant rule's line ± its parent section, and
   decide by the WHY, never by local convenience (READ, 9–37).
-- Checking your work → `ACCEPT` (641–658).
+- Checking your work → `ACCEPT` (651–668).

--- a/CONTRACTS/MAIN.md
+++ b/CONTRACTS/MAIN.md
@@ -477,6 +477,14 @@ Each handler: source env + deps, `db_ensure`, then the logic below.
 - `show`: effective values + overrides from `$ENV_FILE`.
 - `set <KEY> <VAL>`: validate KEY against the known set; write `REFOCUS_<KEY>` to
   `$ENV_FILE`. `unset`: remove the line. `$ENV_FILE` from env.sh (CONV-ENVFILE).
+- Both edits go through `_rewrite_env` (CONV-PORTABLE): `sed` into a temp file,
+  then `cat` the temp file's contents back into `$ENV_FILE` — never `mv` the
+  temp file over it. `mv` swaps the inode in, and mktemp's default mode is
+  0600, so a plain rename silently drops `$ENV_FILE`'s real permissions on
+  every edit. `setup.sh`'s uninstall rewrite of `~/.bashrc` follows the same
+  rule with its own inline copy — it runs standalone before install and
+  doesn't source `lib/`, so sharing `_rewrite_env` isn't worth a cross-layer
+  dependency for three lines.
 
 ### CMD-EXPORT · `focus export [basename]`
 - write `<base>.sql` (`db_dump_sql`) and `<base>.json`. Read-only on live data.

--- a/CONTRACTS/MAIN.md
+++ b/CONTRACTS/MAIN.md
@@ -240,7 +240,17 @@ The exact intent API the core calls through. A rebuild must expose equivalently
 named functions with these contracts. Output of reads is pipe-separated.
 
 **Engine (private):** `_q` (escape single quotes), `_exec` (write, dies loud),
-`_query` (read, `-separator '|'`).
+`_query` (read, `-separator '|'`), `_validate_project_name` (PORT-PROJVALID).
+
+**PORT-PROJVALID:** every write function that takes a project name calls
+`_validate_project_name` first and propagates its failure (exit 2, CONV-EXIT).
+Reads are pipe-separated (`_query -separator '|'`) and every caller splits on
+`IFS='|' read`; a project name containing `|`, `\n`, or `\r` desyncs every
+field after it in that row. Called from `start_session`, `record_session`,
+`record_duration_session`, `update_session`, `update_duration_session`.
+**Not** called from `db_import_session_row` — that path is documented
+verbatim reconstruction (see Serialization below), and guarding it would
+abort an import partway through rather than reject cleanly up front.
 
 **Schema (db_*, storage):**
 - `db_init` — create tables if absent; `INSERT OR IGNORE` the singleton state row.

--- a/core/text.sh
+++ b/core/text.sh
@@ -22,6 +22,11 @@ notes_block() {
     # notes_decode first. Decoding here too would turn a backslash-n the user
     # actually typed into a line break.
     local first="$1" cont="$2" notes="${3:-}" n=0 line
+    # Strip one trailing newline before re-adding exactly one below: without
+    # this, a note that already ends in \n gets a second one appended, and
+    # the read loop sees an extra empty final "line" — a spurious blank
+    # continuation row after the real content.
+    notes="${notes%$'\n'}"
     while IFS= read -r line; do
         if [[ $n -eq 0 ]]; then
             printf '%s%s\n' "$first" "$line"

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -7,6 +7,17 @@ wants_help "$@" && show_help config
 
 # ENV_FILE is exported by env.sh — no need to re-derive it here.
 
+_rewrite_env() {
+    # <sed-expr> -> apply it to ENV_FILE in place. Writes into the original
+    # file rather than `mv`-replacing it: mktemp defaults to mode 0600, and
+    # `mv` would swap the inode in, silently dropping ENV_FILE's real
+    # permissions to 0600 on every edit.
+    local expr="$1" tmp
+    tmp=$(mktemp "${ENV_FILE}.XXXXXX")
+    sed "$expr" "$ENV_FILE" > "$tmp" && cat "$tmp" > "$ENV_FILE"
+    rm -f "$tmp"
+}
+
 _show() {
     echo "Effective configuration:"
     printf "  %-24s = %s\n" "DB_PATH"            "$DB_PATH"
@@ -50,11 +61,7 @@ case "$sub" in
         env_key="REFOCUS_${key}"
         touch "$ENV_FILE"
         if grep -q "^${env_key}=" "$ENV_FILE" 2>/dev/null; then
-            # No `sed -i`: GNU takes a bare -i, BSD demands -i ''. Write a sibling
-            # temp file and rename over the original — same filesystem, atomic,
-            # and identical on both platforms.
-            tmp=$(mktemp "${ENV_FILE}.XXXXXX")
-            sed "s|^${env_key}=.*|${env_key}=${val}|" "$ENV_FILE" > "$tmp" && mv "$tmp" "$ENV_FILE"
+            _rewrite_env "s|^${env_key}=.*|${env_key}=${val}|"
         else
             echo "${env_key}=${val}" >> "$ENV_FILE"
         fi
@@ -63,10 +70,7 @@ case "$sub" in
     unset)
         key="${1:-}"; [[ -z "$key" ]] && usage_error config
         env_key="REFOCUS_${key}"
-        if [[ -f "$ENV_FILE" ]]; then
-            tmp=$(mktemp "${ENV_FILE}.XXXXXX")
-            sed "/^${env_key}=/d" "$ENV_FILE" > "$tmp" && mv "$tmp" "$ENV_FILE"
-        fi
+        [[ -f "$ENV_FILE" ]] && _rewrite_env "/^${env_key}=/d"
         echo "✅ Unset $key (reverts to default)"
         ;;
     *)

--- a/services/database.sh
+++ b/services/database.sh
@@ -29,6 +29,21 @@ _query() {
     sqlite3 -separator '|' "$DB_PATH" "$1"
 }
 
+_validate_project_name() {
+    # Every session read is pipe-separated (_query -separator '|') and every
+    # caller splits on it (IFS='|' read); a project name carrying '|' or a
+    # newline desyncs every field after it. Called by every write path that
+    # takes a project name from a user-controlled arg. db_import_session_row
+    # is exempt on purpose: it is documented as a verbatim reconstruction
+    # path, and guarding it would abort an import partway through.
+    case "$1" in
+        *'|'*|*$'\n'*|*$'\r'*)
+            echo "❌ Invalid character in project name." >&2
+            echo "   Project names cannot contain: | (pipe), newline, carriage return" >&2
+            return 2 ;;
+    esac
+}
+
 # ── Schema lifecycle (db_*: storage-mechanism) ───────────────────────────────
 
 db_init() {
@@ -101,6 +116,7 @@ set_focus_disabled() {
 
 start_session() {
     local project="$1" start_time="$2"
+    _validate_project_name "$project" || return 2
     _exec "UPDATE state SET
         active=1, project='$(_q "$project")', start_time='$(_q "$start_time")',
         paused=0, pause_start_time=NULL, previous_elapsed=0
@@ -138,6 +154,7 @@ resume_session() {
 
 record_session() {
     local project="$1" start_time="$2" end_time="$3" duration="$4" notes="${5:-}"
+    _validate_project_name "$project" || return 2
     _exec "INSERT INTO sessions (project, start_time, end_time, duration_seconds, notes)
            VALUES ('$(_q "$project")', '$(_q "$start_time")', '$(_q "$end_time")',
                    $duration, '$(_q "$notes")');"
@@ -145,12 +162,14 @@ record_session() {
 
 record_duration_session() {
     local project="$1" duration="$2" date="$3" notes="${4:-}"
+    _validate_project_name "$project" || return 2
     _exec "INSERT INTO sessions (project, duration_seconds, notes, duration_only, session_date)
            VALUES ('$(_q "$project")', $duration, '$(_q "$notes")', 1, '$(_q "$date")');"
 }
 
 update_session() {
     local id="$1" project="$2" start_time="$3" end_time="$4" duration="$5"
+    _validate_project_name "$project" || return 2
     _exec "UPDATE sessions SET
         project='$(_q "$project")', start_time='$(_q "$start_time")',
         end_time='$(_q "$end_time")', duration_seconds=$duration
@@ -285,6 +304,7 @@ db_import_session_row() {
 update_duration_session() {
     # Rename and/or re-duration a duration-only session. Never touches timestamps.
     local id="$1" project="$2" duration="$3"
+    _validate_project_name "$project" || return 2
     _exec "UPDATE sessions SET project='$(_q "$project")', duration_seconds=$duration WHERE id=$id;"
 }
 

--- a/services/database.sh
+++ b/services/database.sh
@@ -205,35 +205,38 @@ list_sessions() {
             ORDER BY id DESC LIMIT $limit;"
 }
 
+_range_where() {
+    # <start> <end> -> the WHERE fragment matching sessions in that range,
+    # timestamped or duration-only. Shared so list_sessions_in_range and
+    # get_project_totals_in_range can never drift apart on what "in range"
+    # means — the breakdown must count exactly the sessions the raw listing
+    # shows.
+    local start="$1" end="$2"
+    echo "(
+                (duration_only=0 AND end_time >= '$(_q "$start")' AND end_time <= '$(_q "$end")')
+                OR
+                (duration_only=1 AND session_date >= date('$(_q "$start")') AND session_date <= date('$(_q "$end")'))
+            )"
+}
+
 list_sessions_in_range() {
     local start="$1" end="$2"
     _query "SELECT id, project, COALESCE(start_time,''), COALESCE(end_time,''),
                    duration_seconds, $_NOTES_ENCODED, duration_only, COALESCE(session_date,'')
             FROM sessions
-            WHERE (
-                (duration_only=0 AND end_time >= '$(_q "$start")' AND end_time <= '$(_q "$end")')
-                OR
-                (duration_only=1 AND session_date >= date('$(_q "$start")') AND session_date <= date('$(_q "$end")'))
-            )
+            WHERE $(_range_where "$start" "$end")
             ORDER BY COALESCE(end_time, session_date) DESC;"
 }
 
 get_project_totals_in_range() {
     # <start> <end> -> project|duration_seconds|session_count, one row per
-    # project, ordered by duration_seconds descending.
-    #
-    # Same WHERE clause as list_sessions_in_range on purpose: report's
-    # per-project breakdown must count exactly the sessions the raw listing
-    # shows. Aggregating here rather than in bash means `focus report` has no
-    # associative-array dependency — macOS ships bash 3.2, which has none.
+    # project, ordered by duration_seconds descending. Aggregating in SQL
+    # rather than bash means `focus report` has no associative-array
+    # dependency — macOS ships bash 3.2, which has none.
     local start="$1" end="$2"
     _query "SELECT project, SUM(duration_seconds), COUNT(*)
             FROM sessions
-            WHERE (
-                (duration_only=0 AND end_time >= '$(_q "$start")' AND end_time <= '$(_q "$end")')
-                OR
-                (duration_only=1 AND session_date >= date('$(_q "$start")') AND session_date <= date('$(_q "$end")'))
-            )
+            WHERE $(_range_where "$start" "$end")
             GROUP BY project
             ORDER BY SUM(duration_seconds) DESC;"
 }

--- a/setup.sh
+++ b/setup.sh
@@ -192,12 +192,15 @@ case "${1:-install}" in
         rm -f  "$BIN_DIR/focus"
         rm -f  "$HOME/.local/share/applications/refocus.desktop"
         rc="$HOME/.bashrc"
-        # No `sed -i`: GNU takes a bare -i, BSD demands -i ''. Sibling temp + rename
-        # behaves identically on both.
+        # No `sed -i` (GNU takes a bare -i, BSD demands -i ''), and no `mv`
+        # over the original either: that would swap in mktemp's default 0600
+        # mode. Write the result back into the original file instead, so its
+        # permissions survive untouched.
         if [[ -f "$rc" ]]; then
             rc_tmp=$(mktemp "${rc}.XXXXXX")
             sed -e '/# Refocus Shell/d' -e '/focus-function\.sh/d' "$rc" > "$rc_tmp" \
-                && mv "$rc_tmp" "$rc"
+                && cat "$rc_tmp" > "$rc"
+            rm -f "$rc_tmp"
         fi
         _ok "Uninstalled."
         ;;

--- a/tests/state-matrix.sh
+++ b/tests/state-matrix.sh
@@ -234,6 +234,19 @@ out=$(./focus config show 2>&1); rc=$?
 chk "config show rc=0 with overrides" "0" "$rc"
 chk "config show renders override"   "0" "$([[ "$out" == *"NUDGE_INTERVAL=11"* ]]; echo $?)"
 
+# ── config set/unset: file mode survives the rewrite ─────────────────────────
+# `mv` over a mktemp file drops ENV_FILE from its real mode to mktemp's
+# default 0600. Writing back into the original file instead of replacing it
+# must leave the mode untouched.
+echo "── config: file mode preserved ──"
+env_file="$SANDBOX/.env"
+./focus config set REPORT_LIMIT 6 >/dev/null 2>&1
+chmod 644 "$env_file"
+./focus config set REPORT_LIMIT 7 >/dev/null 2>&1
+chk "config set preserves 644"   "-rw-r--r--" "$(ls -l "$env_file" | cut -c1-10)"
+./focus config unset REPORT_LIMIT >/dev/null 2>&1
+chk "config unset preserves 644" "-rw-r--r--" "$(ls -l "$env_file" | cut -c1-10)"
+
 # ── project name guard: '|' desyncs every pipe-separated read ───────────────
 # _query uses `sqlite3 -separator '|'` and every caller splits on IFS='|'; a
 # project name containing the separator corrupts every field after it.

--- a/tests/state-matrix.sh
+++ b/tests/state-matrix.sh
@@ -234,6 +234,17 @@ out=$(./focus config show 2>&1); rc=$?
 chk "config show rc=0 with overrides" "0" "$rc"
 chk "config show renders override"   "0" "$([[ "$out" == *"NUDGE_INTERVAL=11"* ]]; echo $?)"
 
+# ── project name guard: '|' desyncs every pipe-separated read ───────────────
+# _query uses `sqlite3 -separator '|'` and every caller splits on IFS='|'; a
+# project name containing the separator corrupts every field after it.
+echo "── project name guard ──"
+sessions_before_guard=$(cnt)
+printf 'n\n' | ./focus past add 'evil|project' 2026/06/11-10:00 2026/06/11-11:00 >/dev/null 2>&1
+chk "past add '|' name rc=2"        "2" "$?"
+chk "past add '|' name writes nothing" "$sessions_before_guard" "$(cnt)"
+./focus on 'a|b' >/dev/null 2>&1; chk "on '|' name rc=2" "2" "$?"
+chk "on '|' name leaves state idle" "0|0|0|-" "$(st)"
+
 # ── result ───────────────────────────────────────────────────────────────────
 echo
 total=$(( pass + fail ))

--- a/tests/state-matrix.sh
+++ b/tests/state-matrix.sh
@@ -200,6 +200,11 @@ printf 'replaced\n' | ./focus past modify "$nid" --notes >/dev/null 2>&1
 chk "--notes rewrites note"      "replaced"     "$(sqlite3 "$REFOCUS_DB_PATH" "SELECT notes FROM sessions WHERE id=$nid;")"
 chk "--notes preserves duration" "$dur_before"  "$(sqlite3 "$REFOCUS_DB_PATH" "SELECT duration_seconds FROM sessions WHERE id=$nid;")"
 
+# notes_block must not render a spurious blank line for a note that already
+# ends in a newline (printf '%s\n' would otherwise double it up).
+chk "notes_block: no spurious blank on trailing newline" "2" \
+    "$(bash -c "source core/text.sh; notes_block '' '' \$'a\nb\n'" | wc -l | tr -d ' ')"
+
 # ── report: empty period ─────────────────────────────────────────────────────
 # `declare -A` left the array unset, so ${#arr[@]} tripped set -u and any
 # period with no sessions exited 1.


### PR DESCRIPTION
- services/database.sh: reject `|`/newline in project names before write (breaks pipe-separated reads)
- lib/config.sh, setup.sh: preserve file mode on config/uninstall rewrites (mv was replacing the inode with mktemp's 0600)
- services/database.sh: extract shared `_range_where` from list_sessions_in_range / get_project_totals_in_range
- core/text.sh: fix spurious blank line in notes_block for notes with a trailing newline

Refs #28 (test-anchoring gap, filed separately, not fixed here).

tests/audit.sh: 0. tests/state-matrix.sh: 57/57. tests/time-portability.sh: 20/20.