### PR TITLE
fix(services): make note clearing a deliberate $EDITOR-only act

### DIFF
--- a/CONTRACTS/CONTRACT_INDEX.md
+++ b/CONTRACTS/CONTRACT_INDEX.md
@@ -1,6 +1,6 @@
 # CONTRACT_INDEX.md — refocus-shell
 
-> Line-range index into `MAIN.md` (676 lines). Lets an agent load a single
+> Line-range index into `MAIN.md` (690 lines). Lets an agent load a single
 > section or rule by range instead of the whole spec — context budget for small-
 > window models, precise citation for everyone else.
 >
@@ -28,10 +28,10 @@
 | CMD    | Command surface (lib/)                   | 394–516 |
 | NUDGE  | Nudge payload (focus-nudge)              | 518–536 |
 | SM     | State machine                            | 538–557 |
-| CONV   | Conventions                              | 559–603 |
-| INT    | Install & shell integration              | 605–638 |
-| BUILD  | Build guardrails                         | 640–657 |
-| ACCEPT | Acceptance                               | 659–676 |
+| CONV   | Conventions                              | 559–617 |
+| INT    | Install & shell integration              | 619–652 |
+| BUILD  | Build guardrails                         | 654–671 |
+| ACCEPT | Acceptance                               | 673–690 |
 
 ---
 
@@ -92,9 +92,9 @@
 | ENV  | env.sh — loader + exports + precedence | 352–369 |
 | CRON | cron.sh — install/remove + entry format | 371–392 |
 | NUDGE | focus-nudge — the cron payload | 518–536 |
-| INT-INSTALL | setup.sh | 612–622 |
-| INT-DESKTOP | refocus.desktop | 624–627 |
-| INT-SHELL   | focus-function.sh | 629–638 |
+| INT-INSTALL | setup.sh | 626–636 |
+| INT-DESKTOP | refocus.desktop | 638–641 |
+| INT-SHELL   | focus-function.sh | 643–652 |
 
 Note: `services/help.sh` and `services/editor.sh` have no surface section of
 their own — they are specified where they are used, at CMD-HELP (505–516) and
@@ -132,16 +132,17 @@ by its bullet in [CONV] and referenced from the commands it governs.
 | CONV-HELP              | help is data; no inline usage strings | 575 | CONV |
 | CONV-ID                | session ids validated in the handler | 580 | CONV |
 | CONV-NOTES             | encode/decode notes across the read boundary | 583 | CONV |
-| CONV-PORTABLE          | GNU+BSD+bash-3.2; no date(1)/sed -i/sed t;/declare -A | 586 | CONV |
+| CONV-NOTES-CLEAR       | clearing a note requires $EDITOR; never inferred from silence | 586 | CONV |
+| CONV-PORTABLE          | GNU+BSD+bash-3.2; no date(1)/sed -i/sed t;/declare -A | 600 | CONV |
 | CONV-ENVFILE           | ENV_FILE computed once in env.sh | 365 | ENV |
 | CRON-BIN               | payload path resolved at call time | 379 | CRON |
 | CRON-ENV               | entry embeds REFOCUS_ROOT + display env | 381 | CRON |
 | CRON-STRIP             | fixed-string crontab strip, live only | 385 | CRON |
 | CRON-INTERVAL          | validate 1–60 numeric | 389 | CRON |
-| BUILD-NO-REGEN         | no whole-file regen through escaping | 645 | BUILD |
-| BUILD-VERIFY           | run both test scripts after changes | 650 | BUILD |
-| BUILD-UTF8             | shellcheck under LC_ALL=C.UTF-8 | 653 | BUILD |
-| BUILD-SCOPE            | one concern per change | 655 | BUILD |
+| BUILD-NO-REGEN         | no whole-file regen through escaping | 659 | BUILD |
+| BUILD-VERIFY           | run both test scripts after changes | 664 | BUILD |
+| BUILD-UTF8             | shellcheck under LC_ALL=C.UTF-8 | 667 | BUILD |
+| BUILD-SCOPE            | one concern per change | 669 | BUILD |
 
 ---
 
@@ -149,7 +150,7 @@ by its bullet in [CONV] and referenced from the commands it governs.
 
 - Rebuilding a single component → load its surface row from *Component surfaces*
   plus every `INV-*` (124–179) and `NAME` (181–201). The invariants bind all of them.
-- Implementing one command → load its `CMD-*` row + `PORT` (237–311) + `CONV` (559–603).
+- Implementing one command → load its `CMD-*` row + `PORT` (237–311) + `CONV` (559–617).
 - Resolving an ambiguity → load the relevant rule's line ± its parent section, and
   decide by the WHY, never by local convenience (READ, 9–37).
-- Checking your work → `ACCEPT` (659–676).
+- Checking your work → `ACCEPT` (673–690).

--- a/CONTRACTS/MAIN.md
+++ b/CONTRACTS/MAIN.md
@@ -583,6 +583,20 @@ active          1 0 0      paused          0 1 0
 - CONV-NOTES: notes may contain newlines; session reads may not (PORT-NOTES).
   Encode in the adapter, decode with `notes_decode`, render with `notes_block`.
   Never print a note straight from a read.
+- CONV-NOTES-CLEAR: clearing an existing note is only ever a deliberate act
+  done through `$EDITOR` — open it, delete everything, save. `capture_notes`
+  (services/editor.sh) never infers "clear" from silence, in either
+  non-editor path:
+  - Non-interactive (piped/redirected stdin): empty input while re-editing an
+    existing note (`initial` non-empty) is a **usage error, exit 2**
+    (CONV-EXIT) — not "keep", not "clear". `focus past modify <id> --notes
+    </dev/null` refuses rather than guessing. A *fresh* note (off/add,
+    `initial` empty) is unaffected: empty input there still just means no
+    note, as it always has.
+  - Interactive with no editor found (`_resolve_editor` returns empty):
+    bare Enter leaves the existing note untouched — "Enter to skip" means
+    skip, not wipe. Typing text replaces it. This degraded fallback cannot
+    clear a note at all; that always requires a real editor.
 - CONV-PORTABLE: the tool targets GNU and BSD userland, **and bash 3.2** — macOS
   ships 3.2 as `/bin/bash` (GPLv3; Apple will not move), and the shebang is
   `#!/usr/bin/env bash`, so nothing forces a newer one onto PATH. Three concrete

--- a/docs/help/past.txt
+++ b/docs/help/past.txt
@@ -20,5 +20,9 @@ note carries no timestamps. list shows the most recent first.
 Notes open in $EDITOR, so they can run to several lines. Piped input works too:
   echo "shipped the parser" | focus past add refactor 14:00 15:30
 
+To clear an existing note, edit it and save an empty file. Piping nothing to
+`modify --notes` on a session that already has a note is a usage error, not
+a silent clear — say what you mean.
+
 times       YYYY/MM/DD-HH:MM   14:30   "yesterday 14:00"   "2 hours ago"
 durations   1h30m   2h   45m

--- a/lib/past.sh
+++ b/lib/past.sh
@@ -136,7 +136,7 @@ case "$sub" in
         # Notes last, and legal on duration-only rows too: a note bolts no
         # timestamps onto them [CONV-DURONLY]. Pre-loaded with what is there.
         if [[ $want_notes -eq 1 ]]; then
-            echo "📝 Notes (empty to clear)"
+            echo "📝 Notes (edit; delete everything and save to clear)"
             new_notes=$(capture_notes "$(notes_decode "$cur_notes")")
             update_session_notes "$id" "$new_notes"
         fi

--- a/services/editor.sh
+++ b/services/editor.sh
@@ -9,8 +9,10 @@
 # stored the first line and left the rest in the terminal, where the shell ran
 # them as commands.
 #
-# Contract: always succeeds. Handlers run under `set -e` and a note is never
-# worth aborting a session write over.
+# Contract: succeeds unless invoked non-interactively to re-edit an existing
+# note with nothing piped in (see capture_notes below) — that case is a usage
+# error, not a silent guess at "keep" or "clear". Handlers run under `set -e`,
+# so a non-zero return aborts the command; callers don't need to check it.
 
 _NOTES_HEADER="# Lines starting with # are ignored. Save an empty file to skip."
 
@@ -41,21 +43,37 @@ capture_notes() {
 
     # Not a terminal: cron, a pipeline, or `</dev/null`. Take the whole stream
     # as the note, so `echo "..." | focus off` still works — and now keeps
-    # every line of it. Empty stdin falls back to what we were handed.
+    # every line of it.
+    #
+    # Empty stdin: for a fresh note (initial is empty — off/add) that just
+    # means "no note", same as always. For a re-edit (initial is an existing
+    # note — past modify --notes) it's ambiguous whether nothing-piped means
+    # "leave it alone" or "clear it", and guessing either way is how this
+    # bug existed in the first place. Refuse instead: clearing a note is only
+    # ever a deliberate act done through $EDITOR (delete everything, save).
     if [[ ! -t 0 ]]; then
         local piped; piped=$(cat)
-        printf '%s' "${piped:-$initial}"
+        if [[ -z "$piped" && -n "$initial" ]]; then
+            echo "❌ --notes needs input when run non-interactively (stdin was empty)." >&2
+            echo "   To clear a note, edit it in \$EDITOR and save an empty file." >&2
+            return 2
+        fi
+        printf '%s' "$piped"
         return 0
     fi
 
     local ed; ed=$(_resolve_editor)
     if [[ -z "$ed" ]]; then
-        # No editor on the box at all (a stripped container image). Fall back to
-        # the old single-line prompt rather than silently dropping the note.
+        # No editor on the box at all (a stripped container image). Degraded
+        # single-line prompt: Enter means skip — leave initial untouched,
+        # same as it would be if there were nothing to type. Typing text
+        # replaces it. There's no way to clear an existing note from this
+        # fallback: that needs $EDITOR (delete everything, save), same as
+        # the non-interactive path above.
         local line=""
         printf '📝 Notes (Enter to skip): ' >/dev/tty
         read -r line || true
-        printf '%s' "$line"
+        printf '%s' "${line:-$initial}"
         return 0
     fi
 

--- a/tests/state-matrix.sh
+++ b/tests/state-matrix.sh
@@ -200,6 +200,19 @@ printf 'replaced\n' | ./focus past modify "$nid" --notes >/dev/null 2>&1
 chk "--notes rewrites note"      "replaced"     "$(sqlite3 "$REFOCUS_DB_PATH" "SELECT notes FROM sessions WHERE id=$nid;")"
 chk "--notes preserves duration" "$dur_before"  "$(sqlite3 "$REFOCUS_DB_PATH" "SELECT duration_seconds FROM sessions WHERE id=$nid;")"
 
+# --notes piped with nothing on stdin, against an existing note, is a usage
+# error rather than a silent guess at "keep" or "clear" — clearing is only
+# ever a deliberate act done through $EDITOR.
+printf '' | ./focus past modify "$nid" --notes >/dev/null 2>&1
+chk "--notes empty pipe on existing note rc=2" "2" "$?"
+chk "--notes empty pipe leaves note unchanged" "replaced" \
+    "$(sqlite3 "$REFOCUS_DB_PATH" "SELECT notes FROM sessions WHERE id=$nid;")"
+
+# A fresh note (no existing content — off/add) keeps meaning "no note" on
+# empty input; the usage-error path above only applies to re-editing.
+printf '' | ./focus past add note/fresh 2026/06/11-16:00 2026/06/11-16:30 >/dev/null 2>&1
+chk "empty pipe on a fresh note rc=0" "0" "$?"
+
 # notes_block must not render a spurious blank line for a note that already
 # ends in a newline (printf '%s\n' would otherwise double it up).
 chk "notes_block: no spurious blank on trailing newline" "2" \


### PR DESCRIPTION
Two capture_notes bugs shared one root cause: neither non-editor path could tell "leave alone" from "clear" apart from silence, so each guessed, and each guessed wrong in a different direction.

- Piped/redirected stdin (`focus past modify <id> --notes </dev/null`) fell back to the old note on empty input, so a script trying to clear a note silently did nothing.
- The no-editor interactive fallback did the opposite: bare Enter at "Enter to skip" wiped the note instead of skipping.

Resolved by making clearing exclusively a $EDITOR act — open it, delete everything, save — and refusing to infer it anywhere else:

- Piped path: empty input while re-editing an existing note is now a usage error, exit 2, not a guess. A fresh note (off/add, no existing content) is unaffected — empty input there still just means no note.
- No-editor fallback: Enter now genuinely leaves the note untouched; typing text still replaces it. This path can't clear a note at all — that always needs a real editor.

Documented as CONV-NOTES-CLEAR in CONTRACTS/MAIN.md, plus a doc note in docs/help/past.txt.

Verified live, including the no-editor fallback over a real pty (PATH stripped of every editor): bare Enter preserves the note, typed text replaces it, and the editor path's existing "delete + save empty = clear" behavior is untouched.

tests/audit.sh: 0. tests/state-matrix.sh: 60/60 (was 57).
tests/time-portability.sh: 20/20.