### PR TITLE
fix(database): CHECK-constrain project names; strip all trailing newl…

### DIFF
--- a/CONTRACTS/CONTRACT_INDEX.md
+++ b/CONTRACTS/CONTRACT_INDEX.md
@@ -1,6 +1,6 @@
 # CONTRACT_INDEX.md — refocus-shell
 
-> Line-range index into `MAIN.md` (690 lines). Lets an agent load a single
+> Line-range index into `MAIN.md` (707 lines). Lets an agent load a single
 > section or rule by range instead of the whole spec — context budget for small-
 > window models, precise citation for everyone else.
 >
@@ -21,17 +21,17 @@
 | INV    | Invariants                               | 124–179 |
 | NAME   | Naming contract                          | 181–201 |
 | ARCH   | Architecture & layering                  | 203–235 |
-| PORT   | Adapter surface (database.sh)            | 237–311 |
-| CORE   | Domain-helper surface (core/*.sh)        | 313–350 |
-| ENV    | Environment loader (env.sh)              | 352–369 |
-| CRON   | Nudge scheduling (cron.sh)               | 371–392 |
-| CMD    | Command surface (lib/)                   | 394–516 |
-| NUDGE  | Nudge payload (focus-nudge)              | 518–536 |
-| SM     | State machine                            | 538–557 |
-| CONV   | Conventions                              | 559–617 |
-| INT    | Install & shell integration              | 619–652 |
-| BUILD  | Build guardrails                         | 654–671 |
-| ACCEPT | Acceptance                               | 673–690 |
+| PORT   | Adapter surface (database.sh)            | 237–328 |
+| CORE   | Domain-helper surface (core/*.sh)        | 330–367 |
+| ENV    | Environment loader (env.sh)              | 369–386 |
+| CRON   | Nudge scheduling (cron.sh)               | 388–409 |
+| CMD    | Command surface (lib/)                   | 411–533 |
+| NUDGE  | Nudge payload (focus-nudge)              | 535–553 |
+| SM     | State machine                            | 555–574 |
+| CONV   | Conventions                              | 576–634 |
+| INT    | Install & shell integration              | 636–669 |
+| BUILD  | Build guardrails                         | 671–688 |
+| ACCEPT | Acceptance                               | 690–707 |
 
 ---
 
@@ -62,22 +62,22 @@
 
 | Code | Command | Lines |
 |---|---|---|
-| CMD-ON       | focus on [project] | 398–406 |
-| CMD-OFF      | focus off | 408–414 |
-| CMD-PAUSE    | focus pause | 416–418 |
-| CMD-CONTINUE | focus continue | 420–424 |
-| CMD-STATUS   | focus status | 426–429 |
-| CMD-PAST     | focus past <list\|add\|modify\|delete> | 431–455 |
-| CMD-REPORT   | focus report <today\|week\|month\|custom N> | 457–462 |
-| CMD-ENABLE   | focus enable | 464–466 |
-| CMD-DISABLE  | focus disable | 468–470 |
-| CMD-NUDGE    | focus nudge <status\|test> | 472–474 |
-| CMD-CONFIG   | focus config <show\|set\|unset> | 476–487 |
-| CMD-EXPORT   | focus export [basename] | 489–490 |
-| CMD-IMPORT   | focus import <file> | 492–496 |
-| CMD-INIT     | focus init | 498–499 |
-| CMD-RESET    | focus reset | 501–503 |
-| CMD-HELP     | focus help [cmd] | 505–516 |
+| CMD-ON       | focus on [project] | 415–423 |
+| CMD-OFF      | focus off | 425–431 |
+| CMD-PAUSE    | focus pause | 433–435 |
+| CMD-CONTINUE | focus continue | 437–441 |
+| CMD-STATUS   | focus status | 443–446 |
+| CMD-PAST     | focus past <list\|add\|modify\|delete> | 448–472 |
+| CMD-REPORT   | focus report <today\|week\|month\|custom N> | 474–479 |
+| CMD-ENABLE   | focus enable | 481–483 |
+| CMD-DISABLE  | focus disable | 485–487 |
+| CMD-NUDGE    | focus nudge <status\|test> | 489–491 |
+| CMD-CONFIG   | focus config <show\|set\|unset> | 493–504 |
+| CMD-EXPORT   | focus export [basename] | 506–507 |
+| CMD-IMPORT   | focus import <file> | 509–513 |
+| CMD-INIT     | focus init | 515–516 |
+| CMD-RESET    | focus reset | 518–520 |
+| CMD-HELP     | focus help [cmd] | 522–533 |
 
 ---
 
@@ -85,19 +85,19 @@
 
 | Code | Surface | Lines |
 |---|---|---|
-| PORT | database.sh — full intent API | 237–311 |
-| CORE | core/*.sh — time + text helpers | 313–350 |
-| CORE-TIME | core/time.sh — duration/time parsing, GNU-BSD split | 318–338 |
-| CORE-TEXT | core/text.sh — notes decode + block rendering | 340–350 |
-| ENV  | env.sh — loader + exports + precedence | 352–369 |
-| CRON | cron.sh — install/remove + entry format | 371–392 |
-| NUDGE | focus-nudge — the cron payload | 518–536 |
-| INT-INSTALL | setup.sh | 626–636 |
-| INT-DESKTOP | refocus.desktop | 638–641 |
-| INT-SHELL   | focus-function.sh | 643–652 |
+| PORT | database.sh — full intent API | 237–328 |
+| CORE | core/*.sh — time + text helpers | 330–367 |
+| CORE-TIME | core/time.sh — duration/time parsing, GNU-BSD split | 335–355 |
+| CORE-TEXT | core/text.sh — notes decode + block rendering | 357–367 |
+| ENV  | env.sh — loader + exports + precedence | 369–386 |
+| CRON | cron.sh — install/remove + entry format | 388–409 |
+| NUDGE | focus-nudge — the cron payload | 535–553 |
+| INT-INSTALL | setup.sh | 643–653 |
+| INT-DESKTOP | refocus.desktop | 655–658 |
+| INT-SHELL   | focus-function.sh | 660–669 |
 
 Note: `services/help.sh` and `services/editor.sh` have no surface section of
-their own — they are specified where they are used, at CMD-HELP (505–516) and
+their own — they are specified where they are used, at CMD-HELP (522–533) and
 CMD-OFF / CMD-PAST respectively.
 
 ---
@@ -113,36 +113,36 @@ by its bullet in [CONV] and referenced from the commands it governs.
 | ARCH-ROUTABLE          | dispatcher routes only to lib/ | 223 | ARCH |
 | ARCH-ROOT              | REFOCUS_ROOT via realpath(BASH_SOURCE) | 227 | ARCH |
 | ARCH-SOURCE            | handler source order | 232 | ARCH |
-| PORT-PROJVALID         | project name validated before every DB write | 245 | PORT |
-| PORT-NOTES             | notes encode newlines on read | 288 | PORT |
-| PORT-BASH32            | get_project_totals_in_range aggregates in SQL, not bash | 301 | PORT |
-| CORE-DATE              | date(1) confined to core/time.sh | 331 | CORE-TIME |
-| CMD-OFF-RECOVERY       | off ignores focus_disabled | 412 | CMD-OFF |
-| CMD-PAST-ARGS          | optional leading project; don't eat --duration | 443 | CMD-PAST |
-| CMD-PAST-ID            | numeric id guard before the adapter | 449 | CMD-PAST |
-| CMD-PAST-NOOP          | a modify that changes nothing is exit 2 | 453 | CMD-PAST |
-| CMD-HELP-INTERCEPT     | wants_help runs before parsing and db_ensure | 511 | CMD-HELP |
-| NUDGE-HISTORY          | desktop-entry hint → logged in history | 532 | NUDGE |
-| SM-INVARIANT           | disabled ⇒ idle; active+disabled illegal | 547 | SM |
-| CONV-EXIT              | exit codes 0/1/2 | 561 | CONV |
-| CONV-YES               | destructive ops need literal "yes" | 563 | CONV |
-| CONV-REARM             | reset/import leave disabled | 565 | CONV |
-| CONV-IDEMPOTENT-ENABLE | enable-when-enabled is a no-op | 568 | CONV |
-| CONV-DURONLY           | duration-only rows have no timestamps | 571 | CONV |
-| CONV-HELP              | help is data; no inline usage strings | 575 | CONV |
-| CONV-ID                | session ids validated in the handler | 580 | CONV |
-| CONV-NOTES             | encode/decode notes across the read boundary | 583 | CONV |
-| CONV-NOTES-CLEAR       | clearing a note requires $EDITOR; never inferred from silence | 586 | CONV |
-| CONV-PORTABLE          | GNU+BSD+bash-3.2; no date(1)/sed -i/sed t;/declare -A | 600 | CONV |
-| CONV-ENVFILE           | ENV_FILE computed once in env.sh | 365 | ENV |
-| CRON-BIN               | payload path resolved at call time | 379 | CRON |
-| CRON-ENV               | entry embeds REFOCUS_ROOT + display env | 381 | CRON |
-| CRON-STRIP             | fixed-string crontab strip, live only | 385 | CRON |
-| CRON-INTERVAL          | validate 1–60 numeric | 389 | CRON |
-| BUILD-NO-REGEN         | no whole-file regen through escaping | 659 | BUILD |
-| BUILD-VERIFY           | run both test scripts after changes | 664 | BUILD |
-| BUILD-UTF8             | shellcheck under LC_ALL=C.UTF-8 | 667 | BUILD |
-| BUILD-SCOPE            | one concern per change | 669 | BUILD |
+| PORT-PROJVALID         | project name validated in bash + a schema CHECK backstop (new DBs) | 245 | PORT |
+| PORT-NOTES             | notes encode newlines on read | 305 | PORT |
+| PORT-BASH32            | get_project_totals_in_range aggregates in SQL, not bash | 318 | PORT |
+| CORE-DATE              | date(1) confined to core/time.sh | 348 | CORE-TIME |
+| CMD-OFF-RECOVERY       | off ignores focus_disabled | 429 | CMD-OFF |
+| CMD-PAST-ARGS          | optional leading project; don't eat --duration | 460 | CMD-PAST |
+| CMD-PAST-ID            | numeric id guard before the adapter | 466 | CMD-PAST |
+| CMD-PAST-NOOP          | a modify that changes nothing is exit 2 | 470 | CMD-PAST |
+| CMD-HELP-INTERCEPT     | wants_help runs before parsing and db_ensure | 528 | CMD-HELP |
+| NUDGE-HISTORY          | desktop-entry hint → logged in history | 549 | NUDGE |
+| SM-INVARIANT           | disabled ⇒ idle; active+disabled illegal | 564 | SM |
+| CONV-EXIT              | exit codes 0/1/2 | 578 | CONV |
+| CONV-YES               | destructive ops need literal "yes" | 580 | CONV |
+| CONV-REARM             | reset/import leave disabled | 582 | CONV |
+| CONV-IDEMPOTENT-ENABLE | enable-when-enabled is a no-op | 585 | CONV |
+| CONV-DURONLY           | duration-only rows have no timestamps | 588 | CONV |
+| CONV-HELP              | help is data; no inline usage strings | 592 | CONV |
+| CONV-ID                | session ids validated in the handler | 597 | CONV |
+| CONV-NOTES             | encode/decode notes across the read boundary | 600 | CONV |
+| CONV-NOTES-CLEAR       | clearing a note requires $EDITOR; never inferred from silence | 603 | CONV |
+| CONV-PORTABLE          | GNU+BSD+bash-3.2; no date(1)/sed -i/sed t;/declare -A | 617 | CONV |
+| CONV-ENVFILE           | ENV_FILE computed once in env.sh | 382 | ENV |
+| CRON-BIN               | payload path resolved at call time | 396 | CRON |
+| CRON-ENV               | entry embeds REFOCUS_ROOT + display env | 398 | CRON |
+| CRON-STRIP             | fixed-string crontab strip, live only | 402 | CRON |
+| CRON-INTERVAL          | validate 1–60 numeric | 406 | CRON |
+| BUILD-NO-REGEN         | no whole-file regen through escaping | 676 | BUILD |
+| BUILD-VERIFY           | run both test scripts after changes | 681 | BUILD |
+| BUILD-UTF8             | shellcheck under LC_ALL=C.UTF-8 | 684 | BUILD |
+| BUILD-SCOPE            | one concern per change | 686 | BUILD |
 
 ---
 
@@ -150,7 +150,7 @@ by its bullet in [CONV] and referenced from the commands it governs.
 
 - Rebuilding a single component → load its surface row from *Component surfaces*
   plus every `INV-*` (124–179) and `NAME` (181–201). The invariants bind all of them.
-- Implementing one command → load its `CMD-*` row + `PORT` (237–311) + `CONV` (559–617).
+- Implementing one command → load its `CMD-*` row + `PORT` (237–328) + `CONV` (576–634).
 - Resolving an ambiguity → load the relevant rule's line ± its parent section, and
   decide by the WHY, never by local convenience (READ, 9–37).
-- Checking your work → `ACCEPT` (673–690).
+- Checking your work → `ACCEPT` (690–707).

--- a/CONTRACTS/MAIN.md
+++ b/CONTRACTS/MAIN.md
@@ -252,6 +252,23 @@ field after it in that row. Called from `start_session`, `record_session`,
 verbatim reconstruction (see Serialization below), and guarding it would
 abort an import partway through rather than reject cleanly up front.
 
+The bash guard is a friendly front door, not the only line of defense:
+`db_init`'s `CREATE TABLE` puts the same check directly on the `project`
+column (`CHECK (instr(project, '|') = 0 AND instr(project, char(10)) = 0
+AND instr(project, char(13)) = 0)`, both `state` and `sessions`), so SQLite
+itself rejects a bad write regardless of path — including
+`db_import_session_row`, a raw `sqlite3` edit, or any future write path
+that forgets to call the bash guard. This is the actual fix for the case
+that mattered: an import-tainted `|` in a project name doesn't just
+misdisplay, it desyncs `get_session`'s own read and drives `past modify`
+into misreading its own arguments, corrupting the row further on the next
+command that touches it. **Existing databases are not retrofitted** —
+SQLite can't `ALTER TABLE` a `CHECK` onto a column that already exists
+without a create-copy-swap `db_migrate` doesn't do, and this constraint
+was deliberately scoped to new databases only. A pre-existing DB with a
+tainted row is fixed by hand via `sqlite3`, same as any other legacy data
+issue.
+
 **Schema (db_*, storage):**
 - `db_init` — create tables if absent; `INSERT OR IGNORE` the singleton state row.
 - `db_migrate` — additive-only column adds; never drops (DM-DEAD).

--- a/core/text.sh
+++ b/core/text.sh
@@ -22,11 +22,11 @@ notes_block() {
     # notes_decode first. Decoding here too would turn a backslash-n the user
     # actually typed into a line break.
     local first="$1" cont="$2" notes="${3:-}" n=0 line
-    # Strip one trailing newline before re-adding exactly one below: without
-    # this, a note that already ends in \n gets a second one appended, and
-    # the read loop sees an extra empty final "line" — a spurious blank
-    # continuation row after the real content.
-    notes="${notes%$'\n'}"
+    # Strip ALL trailing newlines before re-adding exactly one below: without
+    # this, a note that already ends in \n (or several) gets one more
+    # appended, and the read loop sees an extra empty final "line" — a
+    # spurious blank continuation row after the real content.
+    while [[ "$notes" == *$'\n' ]]; do notes="${notes%$'\n'}"; done
     while IFS= read -r line; do
         if [[ $n -eq 0 ]]; then
             printf '%s%s\n' "$first" "$line"

--- a/services/database.sh
+++ b/services/database.sh
@@ -52,7 +52,7 @@ db_init() {
         CREATE TABLE IF NOT EXISTS state (
             id               INTEGER PRIMARY KEY CHECK (id = 1),
             active           INTEGER NOT NULL DEFAULT 0,
-            project          TEXT,
+            project          TEXT CHECK (instr(project, '|') = 0 AND instr(project, char(10)) = 0 AND instr(project, char(13)) = 0),
             start_time       TEXT,
             paused           INTEGER NOT NULL DEFAULT 0,
             pause_start_time TEXT,
@@ -62,7 +62,7 @@ db_init() {
         );
         CREATE TABLE IF NOT EXISTS sessions (
             id               INTEGER PRIMARY KEY AUTOINCREMENT,
-            project          TEXT NOT NULL,
+            project          TEXT NOT NULL CHECK (instr(project, '|') = 0 AND instr(project, char(10)) = 0 AND instr(project, char(13)) = 0),
             start_time       TEXT,
             end_time         TEXT,
             duration_seconds INTEGER NOT NULL,

--- a/tests/state-matrix.sh
+++ b/tests/state-matrix.sh
@@ -217,6 +217,8 @@ chk "empty pipe on a fresh note rc=0" "0" "$?"
 # ends in a newline (printf '%s\n' would otherwise double it up).
 chk "notes_block: no spurious blank on trailing newline" "2" \
     "$(bash -c "source core/text.sh; notes_block '' '' \$'a\nb\n'" | wc -l | tr -d ' ')"
+chk "notes_block: no spurious blank on multiple trailing newlines" "2" \
+    "$(bash -c "source core/text.sh; notes_block '' '' \$'a\nb\n\n\n'" | wc -l | tr -d ' ')"
 
 # ── report: empty period ─────────────────────────────────────────────────────
 # `declare -A` left the array unset, so ${#arr[@]} tripped set -u and any
@@ -275,6 +277,13 @@ chk "past add '|' name rc=2"        "2" "$?"
 chk "past add '|' name writes nothing" "$sessions_before_guard" "$(cnt)"
 ./focus on 'a|b' >/dev/null 2>&1; chk "on '|' name rc=2" "2" "$?"
 chk "on '|' name leaves state idle" "0|0|0|-" "$(st)"
+
+# The bash-side guard is a friendly front door; the schema CHECK is the
+# actual backstop for anything that bypasses it (db_import_session_row is
+# deliberately exempt from the bash guard, per its own comment).
+sessions_before_check=$(cnt)
+bash -c 'source env.sh; source services/database.sh; db_import_session_row "bad|import" "" "" 3600 "" 0 "2026-06-11"' >/dev/null 2>&1
+chk "DB-level CHECK blocks '|' bypassing the bash guard" "$sessions_before_check" "$(cnt)"
 
 # ── result ───────────────────────────────────────────────────────────────────
 echo


### PR DESCRIPTION
…ines

_validate_project_name blocked '|'/newline/CR in every write path except one: db_import_session_row, exempt by design since guarding it would abort an import partway through. That exemption turned out sharper than it looked. A row imported with '|' in its name desyncs get_session's own IFS='|' read on the way back out, and every consumer of that read breaks differently: `focus past list` shows garbled columns, `focus report` throws a live `printf: invalid number` and prints nonsense session counts, and `focus past modify` misreads its own state (cur_donly reads wrong) and can silently overwrite the row with garbage — verified live, a duration-only row's project became the literal string "--duration" and its duration became a bogus value after a routine --duration edit.

Fixed at the schema level instead of adding another bash-side check: both `sessions.project` and `state.project` now carry a CHECK constraint doing the same instr()-based rejection SQLite enforces on every write regardless of path — import, a future write path, or a raw sqlite3 edit. The bash guard stays as the friendly front door with an immediate, readable error; the CHECK is the actual backstop. Verified live: db_import_session_row called directly against a fresh DB now fails at the SQL layer with a CHECK constraint error and writes nothing.

Scoped to new databases only, deliberately: SQLite can't ALTER TABLE a CHECK onto an existing column without a create-copy-swap db_migrate doesn't do, and existing DBs aren't retrofitted. Documented in CONTRACTS/MAIN.md (PORT-PROJVALID).

Also: notes_block only stripped one trailing newline, so a note with two or more still produced the spurious blank line the earlier fix targeted. Now loops the strip.

tests/audit.sh: 0. tests/state-matrix.sh: 62/62 (was 60).
tests/time-portability.sh: 20/20.