### PR TITLE
fix: sanitize pipe at input instead of rejecting it, per-field strategy

### DIFF
--- a/CONTRACTS/CONTRACT_INDEX.md
+++ b/CONTRACTS/CONTRACT_INDEX.md
@@ -1,6 +1,6 @@
 # CONTRACT_INDEX.md — refocus-shell
 
-> Line-range index into `MAIN.md` (707 lines). Lets an agent load a single
+> Line-range index into `MAIN.md` (748 lines). Lets an agent load a single
 > section or rule by range instead of the whole spec — context budget for small-
 > window models, precise citation for everyone else.
 >
@@ -21,17 +21,17 @@
 | INV    | Invariants                               | 124–179 |
 | NAME   | Naming contract                          | 181–201 |
 | ARCH   | Architecture & layering                  | 203–235 |
-| PORT   | Adapter surface (database.sh)            | 237–328 |
-| CORE   | Domain-helper surface (core/*.sh)        | 330–367 |
-| ENV    | Environment loader (env.sh)              | 369–386 |
-| CRON   | Nudge scheduling (cron.sh)               | 388–409 |
-| CMD    | Command surface (lib/)                   | 411–533 |
-| NUDGE  | Nudge payload (focus-nudge)              | 535–553 |
-| SM     | State machine                            | 555–574 |
-| CONV   | Conventions                              | 576–634 |
-| INT    | Install & shell integration              | 636–669 |
-| BUILD  | Build guardrails                         | 671–688 |
-| ACCEPT | Acceptance                               | 690–707 |
+| PORT   | Adapter surface (database.sh)            | 237–365 |
+| CORE   | Domain-helper surface (core/*.sh)        | 367–404 |
+| ENV    | Environment loader (env.sh)              | 406–423 |
+| CRON   | Nudge scheduling (cron.sh)               | 425–446 |
+| CMD    | Command surface (lib/)                   | 448–570 |
+| NUDGE  | Nudge payload (focus-nudge)              | 572–590 |
+| SM     | State machine                            | 592–611 |
+| CONV   | Conventions                              | 613–675 |
+| INT    | Install & shell integration              | 677–710 |
+| BUILD  | Build guardrails                         | 712–729 |
+| ACCEPT | Acceptance                               | 731–748 |
 
 ---
 
@@ -62,22 +62,22 @@
 
 | Code | Command | Lines |
 |---|---|---|
-| CMD-ON       | focus on [project] | 415–423 |
-| CMD-OFF      | focus off | 425–431 |
-| CMD-PAUSE    | focus pause | 433–435 |
-| CMD-CONTINUE | focus continue | 437–441 |
-| CMD-STATUS   | focus status | 443–446 |
-| CMD-PAST     | focus past <list\|add\|modify\|delete> | 448–472 |
-| CMD-REPORT   | focus report <today\|week\|month\|custom N> | 474–479 |
-| CMD-ENABLE   | focus enable | 481–483 |
-| CMD-DISABLE  | focus disable | 485–487 |
-| CMD-NUDGE    | focus nudge <status\|test> | 489–491 |
-| CMD-CONFIG   | focus config <show\|set\|unset> | 493–504 |
-| CMD-EXPORT   | focus export [basename] | 506–507 |
-| CMD-IMPORT   | focus import <file> | 509–513 |
-| CMD-INIT     | focus init | 515–516 |
-| CMD-RESET    | focus reset | 518–520 |
-| CMD-HELP     | focus help [cmd] | 522–533 |
+| CMD-ON       | focus on [project] | 452–460 |
+| CMD-OFF      | focus off | 462–468 |
+| CMD-PAUSE    | focus pause | 470–472 |
+| CMD-CONTINUE | focus continue | 474–478 |
+| CMD-STATUS   | focus status | 480–483 |
+| CMD-PAST     | focus past <list\|add\|modify\|delete> | 485–509 |
+| CMD-REPORT   | focus report <today\|week\|month\|custom N> | 511–516 |
+| CMD-ENABLE   | focus enable | 518–520 |
+| CMD-DISABLE  | focus disable | 522–524 |
+| CMD-NUDGE    | focus nudge <status\|test> | 526–528 |
+| CMD-CONFIG   | focus config <show\|set\|unset> | 530–541 |
+| CMD-EXPORT   | focus export [basename] | 543–544 |
+| CMD-IMPORT   | focus import <file> | 546–550 |
+| CMD-INIT     | focus init | 552–553 |
+| CMD-RESET    | focus reset | 555–557 |
+| CMD-HELP     | focus help [cmd] | 559–570 |
 
 ---
 
@@ -85,19 +85,19 @@
 
 | Code | Surface | Lines |
 |---|---|---|
-| PORT | database.sh — full intent API | 237–328 |
-| CORE | core/*.sh — time + text helpers | 330–367 |
-| CORE-TIME | core/time.sh — duration/time parsing, GNU-BSD split | 335–355 |
-| CORE-TEXT | core/text.sh — notes decode + block rendering | 357–367 |
-| ENV  | env.sh — loader + exports + precedence | 369–386 |
-| CRON | cron.sh — install/remove + entry format | 388–409 |
-| NUDGE | focus-nudge — the cron payload | 535–553 |
-| INT-INSTALL | setup.sh | 643–653 |
-| INT-DESKTOP | refocus.desktop | 655–658 |
-| INT-SHELL   | focus-function.sh | 660–669 |
+| PORT | database.sh — full intent API | 237–365 |
+| CORE | core/*.sh — time + text helpers | 367–404 |
+| CORE-TIME | core/time.sh — duration/time parsing, GNU-BSD split | 372–392 |
+| CORE-TEXT | core/text.sh — notes decode + block rendering | 394–404 |
+| ENV  | env.sh — loader + exports + precedence | 406–423 |
+| CRON | cron.sh — install/remove + entry format | 425–446 |
+| NUDGE | focus-nudge — the cron payload | 572–590 |
+| INT-INSTALL | setup.sh | 684–694 |
+| INT-DESKTOP | refocus.desktop | 696–699 |
+| INT-SHELL   | focus-function.sh | 701–710 |
 
 Note: `services/help.sh` and `services/editor.sh` have no surface section of
-their own — they are specified where they are used, at CMD-HELP (522–533) and
+their own — they are specified where they are used, at CMD-HELP (559–570) and
 CMD-OFF / CMD-PAST respectively.
 
 ---
@@ -113,36 +113,36 @@ by its bullet in [CONV] and referenced from the commands it governs.
 | ARCH-ROUTABLE          | dispatcher routes only to lib/ | 223 | ARCH |
 | ARCH-ROOT              | REFOCUS_ROOT via realpath(BASH_SOURCE) | 227 | ARCH |
 | ARCH-SOURCE            | handler source order | 232 | ARCH |
-| PORT-PROJVALID         | project name validated in bash + a schema CHECK backstop (new DBs) | 245 | PORT |
-| PORT-NOTES             | notes encode newlines on read | 305 | PORT |
-| PORT-BASH32            | get_project_totals_in_range aggregates in SQL, not bash | 318 | PORT |
-| CORE-DATE              | date(1) confined to core/time.sh | 348 | CORE-TIME |
-| CMD-OFF-RECOVERY       | off ignores focus_disabled | 429 | CMD-OFF |
-| CMD-PAST-ARGS          | optional leading project; don't eat --duration | 460 | CMD-PAST |
-| CMD-PAST-ID            | numeric id guard before the adapter | 466 | CMD-PAST |
-| CMD-PAST-NOOP          | a modify that changes nothing is exit 2 | 470 | CMD-PAST |
-| CMD-HELP-INTERCEPT     | wants_help runs before parsing and db_ensure | 528 | CMD-HELP |
-| NUDGE-HISTORY          | desktop-entry hint → logged in history | 549 | NUDGE |
-| SM-INVARIANT           | disabled ⇒ idle; active+disabled illegal | 564 | SM |
-| CONV-EXIT              | exit codes 0/1/2 | 578 | CONV |
-| CONV-YES               | destructive ops need literal "yes" | 580 | CONV |
-| CONV-REARM             | reset/import leave disabled | 582 | CONV |
-| CONV-IDEMPOTENT-ENABLE | enable-when-enabled is a no-op | 585 | CONV |
-| CONV-DURONLY           | duration-only rows have no timestamps | 588 | CONV |
-| CONV-HELP              | help is data; no inline usage strings | 592 | CONV |
-| CONV-ID                | session ids validated in the handler | 597 | CONV |
-| CONV-NOTES             | encode/decode notes across the read boundary | 600 | CONV |
-| CONV-NOTES-CLEAR       | clearing a note requires $EDITOR; never inferred from silence | 603 | CONV |
-| CONV-PORTABLE          | GNU+BSD+bash-3.2; no date(1)/sed -i/sed t;/declare -A | 617 | CONV |
-| CONV-ENVFILE           | ENV_FILE computed once in env.sh | 382 | ENV |
-| CRON-BIN               | payload path resolved at call time | 396 | CRON |
-| CRON-ENV               | entry embeds REFOCUS_ROOT + display env | 398 | CRON |
-| CRON-STRIP             | fixed-string crontab strip, live only | 402 | CRON |
-| CRON-INTERVAL          | validate 1–60 numeric | 406 | CRON |
-| BUILD-NO-REGEN         | no whole-file regen through escaping | 676 | BUILD |
-| BUILD-VERIFY           | run both test scripts after changes | 681 | BUILD |
-| BUILD-UTF8             | shellcheck under LC_ALL=C.UTF-8 | 684 | BUILD |
-| BUILD-SCOPE            | one concern per change | 686 | BUILD |
+| PORT-PROJVALID         | project names sanitize (¦); notes encode (\x7c); CHECK backstops both | 246 | PORT |
+| PORT-NOTES             | notes encode newlines/pipe on read | 342 | PORT |
+| PORT-BASH32            | get_project_totals_in_range aggregates in SQL, not bash | 355 | PORT |
+| CORE-DATE              | date(1) confined to core/time.sh | 385 | CORE-TIME |
+| CMD-OFF-RECOVERY       | off ignores focus_disabled | 466 | CMD-OFF |
+| CMD-PAST-ARGS          | optional leading project; don't eat --duration | 497 | CMD-PAST |
+| CMD-PAST-ID            | numeric id guard before the adapter | 503 | CMD-PAST |
+| CMD-PAST-NOOP          | a modify that changes nothing is exit 2 | 507 | CMD-PAST |
+| CMD-HELP-INTERCEPT     | wants_help runs before parsing and db_ensure | 565 | CMD-HELP |
+| NUDGE-HISTORY          | desktop-entry hint → logged in history | 586 | NUDGE |
+| SM-INVARIANT           | disabled ⇒ idle; active+disabled illegal | 601 | SM |
+| CONV-EXIT              | exit codes 0/1/2 | 615 | CONV |
+| CONV-YES               | destructive ops need literal "yes" | 617 | CONV |
+| CONV-REARM             | reset/import leave disabled | 619 | CONV |
+| CONV-IDEMPOTENT-ENABLE | enable-when-enabled is a no-op | 622 | CONV |
+| CONV-DURONLY           | duration-only rows have no timestamps | 625 | CONV |
+| CONV-HELP              | help is data; no inline usage strings | 629 | CONV |
+| CONV-ID                | session ids validated in the handler | 634 | CONV |
+| CONV-NOTES             | encode/decode notes (incl. pipe) across the read boundary | 637 | CONV |
+| CONV-NOTES-CLEAR       | clearing a note requires $EDITOR; never inferred from silence | 644 | CONV |
+| CONV-PORTABLE          | GNU+BSD+bash-3.2; no date(1)/sed -i/sed t;/declare -A | 658 | CONV |
+| CONV-ENVFILE           | ENV_FILE computed once in env.sh | 419 | ENV |
+| CRON-BIN               | payload path resolved at call time | 433 | CRON |
+| CRON-ENV               | entry embeds REFOCUS_ROOT + display env | 435 | CRON |
+| CRON-STRIP             | fixed-string crontab strip, live only | 439 | CRON |
+| CRON-INTERVAL          | validate 1–60 numeric | 443 | CRON |
+| BUILD-NO-REGEN         | no whole-file regen through escaping | 717 | BUILD |
+| BUILD-VERIFY           | run both test scripts after changes | 722 | BUILD |
+| BUILD-UTF8             | shellcheck under LC_ALL=C.UTF-8 | 725 | BUILD |
+| BUILD-SCOPE            | one concern per change | 727 | BUILD |
 
 ---
 
@@ -150,7 +150,7 @@ by its bullet in [CONV] and referenced from the commands it governs.
 
 - Rebuilding a single component → load its surface row from *Component surfaces*
   plus every `INV-*` (124–179) and `NAME` (181–201). The invariants bind all of them.
-- Implementing one command → load its `CMD-*` row + `PORT` (237–328) + `CONV` (576–634).
+- Implementing one command → load its `CMD-*` row + `PORT` (237–365) + `CONV` (613–675).
 - Resolving an ambiguity → load the relevant rule's line ± its parent section, and
   decide by the WHY, never by local convenience (READ, 9–37).
-- Checking your work → `ACCEPT` (690–707).
+- Checking your work → `ACCEPT` (731–748).

--- a/CONTRACTS/MAIN.md
+++ b/CONTRACTS/MAIN.md
@@ -240,34 +240,71 @@ The exact intent API the core calls through. A rebuild must expose equivalently
 named functions with these contracts. Output of reads is pipe-separated.
 
 **Engine (private):** `_q` (escape single quotes), `_exec` (write, dies loud),
-`_query` (read, `-separator '|'`), `_validate_project_name` (PORT-PROJVALID).
+`_query` (read, `-separator '|'`). **Engine (public, called across files):**
+`sanitize_pipe`, `_validate_project_name` (PORT-PROJVALID).
 
-**PORT-PROJVALID:** every write function that takes a project name calls
-`_validate_project_name` first and propagates its failure (exit 2, CONV-EXIT).
-Reads are pipe-separated (`_query -separator '|'`) and every caller splits on
-`IFS='|' read`; a project name containing `|`, `\n`, or `\r` desyncs every
-field after it in that row. Called from `start_session`, `record_session`,
-`record_duration_session`, `update_session`, `update_duration_session`.
-**Not** called from `db_import_session_row` — that path is documented
-verbatim reconstruction (see Serialization below), and guarding it would
-abort an import partway through rather than reject cleanly up front.
+**PORT-PROJVALID:** reads are pipe-separated (`_query -separator '|'`) and
+every caller splits on `IFS='|' read`; a literal `|` in stored data desyncs
+every field after it in that row — reachable through project names, notes,
+or import.
 
-The bash guard is a friendly front door, not the only line of defense:
-`db_init`'s `CREATE TABLE` puts the same check directly on the `project`
-column (`CHECK (instr(project, '|') = 0 AND instr(project, char(10)) = 0
-AND instr(project, char(13)) = 0)`, both `state` and `sessions`), so SQLite
-itself rejects a bad write regardless of path — including
-`db_import_session_row`, a raw `sqlite3` edit, or any future write path
-that forgets to call the bash guard. This is the actual fix for the case
-that mattered: an import-tainted `|` in a project name doesn't just
-misdisplay, it desyncs `get_session`'s own read and drives `past modify`
-into misreading its own arguments, corrupting the row further on the next
-command that touches it. **Existing databases are not retrofitted** —
-SQLite can't `ALTER TABLE` a `CHECK` onto a column that already exists
-without a create-copy-swap `db_migrate` doesn't do, and this constraint
-was deliberately scoped to new databases only. A pre-existing DB with a
-tainted row is fixed by hand via `sqlite3`, same as any other legacy data
-issue.
+Two different mechanisms, one per field type, because the fields have
+different needs:
+
+- **Project names (short identifiers) — transliterate, don't preserve.**
+  `sanitize_pipe` replaces `|` with the visually similar U+00A6 (`¦`) and
+  is called at every point a project name is captured from user input, not
+  just at the final write: `lib/on.sh` and `lib/past.sh`'s `add` case
+  sanitize immediately after reading the raw arg (before any total-time
+  lookup or success message uses it — a second `focus on 'a|b'` must find
+  the total the first one logged under the sanitized name, and the message
+  echoed back must match what's actually stored), and the five adapter
+  write functions (`start_session`, `record_session`,
+  `record_duration_session`, `update_session`, `update_duration_session`)
+  sanitize again on the way in as a second, redundant layer.
+  `_validate_project_name` runs after sanitizing and rejects only `\n`/`\r`
+  outright (exit 2, CONV-EXIT) — a multi-line project name has no sensible
+  meaning for a short identifier, unlike a pipe character, which is
+  ordinary text a person might reasonably type.
+- **Notes (free text) — encode on read, preserve exactly.** See CONV-NOTES;
+  `|` joined `\n`/`\r`/`\\` in `_NOTES_ENCODED`'s escape set. Unlike project
+  names, a note's exact bytes matter, and notes already had a working
+  encode/decode round-trip for other unsafe characters — extending it costs
+  nothing and loses nothing, where transliterating a note would silently
+  change what the user typed.
+
+**`db_import_session_row` sanitizes neither** — it is documented verbatim
+reconstruction (see Serialization below), and guarding it in the adapter
+would abort an import partway through rather than reject cleanly. JSON
+import (`lib/import.sh`) sanitizes the extracted `project` field itself,
+before calling it, so a bad row never reaches this function in practice;
+notes need no import-side handling since they're protected on read
+regardless of how they entered.
+
+**The schema `CHECK` constraint is the backstop behind all of this, not the
+primary mechanism.** `db_init`'s `CREATE TABLE` puts
+`CHECK (instr(project, '|') = 0 AND instr(project, char(10)) = 0 AND
+instr(project, char(13)) = 0)` on `project` in both `state` and `sessions`,
+so SQLite itself rejects a bad write regardless of path — a raw `sqlite3`
+edit, or any future write path that forgets to sanitize. Verified live: a
+direct call to `db_import_session_row` with a raw `|`, bypassing every
+bash-side layer, is still rejected at the SQL layer. **Existing databases
+are not retrofitted** — SQLite can't `ALTER TABLE` a `CHECK` onto a column
+that already exists without a create-copy-swap `db_migrate` doesn't do, and
+this constraint was deliberately scoped to new databases only. A
+pre-existing DB with a tainted row is fixed by hand via `sqlite3`, same as
+any other legacy data issue.
+
+**Why sanitize instead of only relying on the `CHECK`:** an earlier version
+of this fix left `db_import_session_row` unguarded and let the `CHECK`
+reject bad rows outright. That reintroduced the exact "abort an import
+partway through, half-imported DB" failure this exemption exists to avoid
+— verified live, a 3-row JSON import with a bad `|` in the middle row lost
+the row after it entirely, since the per-row `while` loop runs under
+`set -e` and dies at the first `CHECK` failure. Sanitizing at capture time
+means the trigger for that failure mode never occurs during normal
+operation; the `CHECK` stays purely as defense-in-depth for paths nothing
+here controls.
 
 **Schema (db_*, storage):**
 - `db_init` — create tables if absent; `INSERT OR IGNORE` the singleton state row.
@@ -597,9 +634,13 @@ active          1 0 0      paused          0 1 0
 - CONV-ID: session ids are validated in the handler before reaching the adapter
   (CMD-PAST-ID). The adapter interpolates ids into SQL unparameterised, so a
   non-numeric id is a SQL error, not a usage error, unless the handler stops it.
-- CONV-NOTES: notes may contain newlines; session reads may not (PORT-NOTES).
-  Encode in the adapter, decode with `notes_decode`, render with `notes_block`.
-  Never print a note straight from a read.
+- CONV-NOTES: notes may contain newlines or pipes; session reads may not
+  (PORT-NOTES). Encode in the adapter (`_NOTES_ENCODED`: backslash, `\n`,
+  `\r`, then `|` as the hex escape `\x7c` — in that order, backslash first
+  so later steps' own backslashes never get re-escaped), decode with
+  `notes_decode` (`printf %b`, which understands `\x7c` natively — no
+  decoder change needed when `|` was added to the encode side). Render with
+  `notes_block`. Never print a note straight from a read.
 - CONV-NOTES-CLEAR: clearing an existing note is only ever a deliberate act
   done through `$EDITOR` — open it, delete everything, save. `capture_notes`
   (services/editor.sh) never infers "clear" from silence, in either

--- a/lib/import.sh
+++ b/lib/import.sh
@@ -64,6 +64,7 @@ db_init
 # that's from the dead model and silently ignored by the '[]?' optional iterator.
 jq -c '.sessions[]?' "$file" | while IFS= read -r row; do
     project=$(jq -r '.project'            <<< "$row")
+    project="${project//|/¦}"
     start=$(  jq -r '.start_time  // ""'  <<< "$row")
     end=$(    jq -r '.end_time    // ""'  <<< "$row")
     dur=$(    jq -r '.duration_seconds'   <<< "$row")

--- a/lib/on.sh
+++ b/lib/on.sh
@@ -44,6 +44,12 @@ else
     if [[ ${#project} -gt $MAX_PROJECT_LENGTH ]]; then
         echo "❌ Project name too long (max $MAX_PROJECT_LENGTH chars)." >&2; exit 2
     fi
+    # Sanitize before the total-time lookup, not just before start_session:
+    # start_session sanitizes internally too, but doing it here first keeps
+    # the lookup, the prompts below, and the stored row all looking at the
+    # same name — a second `focus on 'a|b'` must find the same total the
+    # first one logged, not 0m under a name nothing was ever stored as.
+    project="${project//|/¦}"
     total=$(get_total_time "$project")
     total_min=$(( total / 60 ))
     if [[ $total_min -gt 0 ]]; then

--- a/lib/past.sh
+++ b/lib/past.sh
@@ -45,6 +45,10 @@ case "$sub" in
     add)
         project="${1:-}"; shift || true
         [[ -z "$project" ]] && usage_error past
+        # Sanitize here, not just inside record_session/record_duration_session:
+        # both echo "$project" back to the user below, and it must match what
+        # actually gets stored.
+        project="${project//|/¦}"
 
         if [[ "${1:-}" == "--duration" ]]; then
             dur_str="${2:-}"; shift 2 || true

--- a/services/database.sh
+++ b/services/database.sh
@@ -29,17 +29,29 @@ _query() {
     sqlite3 -separator '|' "$DB_PATH" "$1"
 }
 
-_validate_project_name() {
+sanitize_pipe() {
     # Every session read is pipe-separated (_query -separator '|') and every
-    # caller splits on it (IFS='|' read); a project name carrying '|' or a
-    # newline desyncs every field after it. Called by every write path that
-    # takes a project name from a user-controlled arg. db_import_session_row
-    # is exempt on purpose: it is documented as a verbatim reconstruction
-    # path, and guarding it would abort an import partway through.
+    # caller splits on it (IFS='|' read); a literal '|' in stored data
+    # desyncs every field after it — reachable through project names, notes,
+    # or import. Rather than rejecting it, transliterate to the visually
+    # similar U+00A6 (broken bar) at every input boundary, so the character
+    # that breaks the format simply never reaches storage. Lossy by design;
+    # applied before validation/storage, not on read.
+    printf '%s' "${1//|/¦}"
+}
+
+_validate_project_name() {
+    # '|' is handled by sanitize_pipe before this ever runs. Newline/CR are
+    # rejected outright instead — a multi-line project name has no sensible
+    # meaning for a short identifier, unlike a pipe character which is
+    # ordinary text. Called by every write path that takes a project name
+    # from a user-controlled arg. db_import_session_row is exempt on
+    # purpose: it is documented as a verbatim reconstruction path, and
+    # guarding it would abort an import partway through.
     case "$1" in
-        *'|'*|*$'\n'*|*$'\r'*)
+        *$'\n'*|*$'\r'*)
             echo "❌ Invalid character in project name." >&2
-            echo "   Project names cannot contain: | (pipe), newline, carriage return" >&2
+            echo "   Project names cannot contain newlines or carriage returns." >&2
             return 2 ;;
     esac
 }
@@ -115,7 +127,8 @@ set_focus_disabled() {
 }
 
 start_session() {
-    local project="$1" start_time="$2"
+    local start_time="$2"
+    local project; project=$(sanitize_pipe "$1")
     _validate_project_name "$project" || return 2
     _exec "UPDATE state SET
         active=1, project='$(_q "$project")', start_time='$(_q "$start_time")',
@@ -153,7 +166,8 @@ resume_session() {
 # ── Sessions: writes ─────────────────────────────────────────────────────────
 
 record_session() {
-    local project="$1" start_time="$2" end_time="$3" duration="$4" notes="${5:-}"
+    local start_time="$2" end_time="$3" duration="$4" notes="${5:-}"
+    local project; project=$(sanitize_pipe "$1")
     _validate_project_name "$project" || return 2
     _exec "INSERT INTO sessions (project, start_time, end_time, duration_seconds, notes)
            VALUES ('$(_q "$project")', '$(_q "$start_time")', '$(_q "$end_time")',
@@ -161,14 +175,16 @@ record_session() {
 }
 
 record_duration_session() {
-    local project="$1" duration="$2" date="$3" notes="${4:-}"
+    local duration="$2" date="$3" notes="${4:-}"
+    local project; project=$(sanitize_pipe "$1")
     _validate_project_name "$project" || return 2
     _exec "INSERT INTO sessions (project, duration_seconds, notes, duration_only, session_date)
            VALUES ('$(_q "$project")', $duration, '$(_q "$notes")', 1, '$(_q "$date")');"
 }
 
 update_session() {
-    local id="$1" project="$2" start_time="$3" end_time="$4" duration="$5"
+    local id="$1" start_time="$3" end_time="$4" duration="$5"
+    local project; project=$(sanitize_pipe "$2")
     _validate_project_name "$project" || return 2
     _exec "UPDATE sessions SET
         project='$(_q "$project")', start_time='$(_q "$start_time")',
@@ -191,11 +207,15 @@ delete_session() {
 
 # ── Sessions: reads ──────────────────────────────────────────────────────────
 
-# Notes are the only free-text column and may hold newlines, but every session
-# read must stay one line per row [PORT]. Encode backslashes first so the decode
-# is reversible, then the line breaks; core/text.sh notes_decode reverses it.
-# char() keeps backslashes out of the SQL source entirely.
-_NOTES_ENCODED="REPLACE(REPLACE(REPLACE(COALESCE(notes,''), char(92), char(92,92)), char(10), char(92,110)), char(13), char(92,114))"
+# Notes are the only free-text column and may hold newlines or pipes, but
+# every session read must stay one line per row [PORT]. Encode backslashes
+# first so the decode is reversible, then everything else; core/text.sh
+# notes_decode reverses it in one pass. char() keeps backslashes (and the
+# literal pipe) out of the SQL source entirely. '|' encodes as the hex escape
+# \x7c rather than a project-name-style transliteration: notes are free text,
+# so the exact byte a user typed should survive the round trip, not get
+# silently substituted.
+_NOTES_ENCODED="REPLACE(REPLACE(REPLACE(REPLACE(COALESCE(notes,''), char(92), char(92,92)), char(10), char(92,110)), char(13), char(92,114)), char(124), char(92,120,55,99))"
 
 list_sessions() {
     local limit="${1:-$REPORT_LIMIT}"
@@ -306,7 +326,8 @@ db_import_session_row() {
 
 update_duration_session() {
     # Rename and/or re-duration a duration-only session. Never touches timestamps.
-    local id="$1" project="$2" duration="$3"
+    local id="$1" duration="$3"
+    local project; project=$(sanitize_pipe "$2")
     _validate_project_name "$project" || return 2
     _exec "UPDATE sessions SET project='$(_q "$project")', duration_seconds=$duration WHERE id=$id;"
 }

--- a/tests/state-matrix.sh
+++ b/tests/state-matrix.sh
@@ -267,16 +267,28 @@ chk "config set preserves 644"   "-rw-r--r--" "$(ls -l "$env_file" | cut -c1-10)
 ./focus config unset REPORT_LIMIT >/dev/null 2>&1
 chk "config unset preserves 644" "-rw-r--r--" "$(ls -l "$env_file" | cut -c1-10)"
 
-# ── project name guard: '|' desyncs every pipe-separated read ───────────────
+# ── project name sanitization: '|' desyncs every pipe-separated read ────────
 # _query uses `sqlite3 -separator '|'` and every caller splits on IFS='|'; a
 # project name containing the separator corrupts every field after it.
-echo "── project name guard ──"
-sessions_before_guard=$(cnt)
+# Rather than rejecting it, every input path transliterates '|' -> '¦'
+# (U+00A6) before it ever reaches storage, so the character that breaks the
+# format never gets there in the first place.
+echo "── project name sanitization ──"
 printf 'n\n' | ./focus past add 'evil|project' 2026/06/11-10:00 2026/06/11-11:00 >/dev/null 2>&1
-chk "past add '|' name rc=2"        "2" "$?"
-chk "past add '|' name writes nothing" "$sessions_before_guard" "$(cnt)"
-./focus on 'a|b' >/dev/null 2>&1; chk "on '|' name rc=2" "2" "$?"
-chk "on '|' name leaves state idle" "0|0|0|-" "$(st)"
+chk "past add '|' name rc=0"      "0" "$?"
+chk "past add '|' name stored as ¦" "1" \
+    "$(sqlite3 "$REFOCUS_DB_PATH" "SELECT COUNT(*) FROM sessions WHERE project='evil¦project';")"
+
+./focus on 'a|b' >/dev/null 2>&1; chk "on '|' name rc=0" "0" "$?"
+chk "on '|' name active, stored as ¦" "1|0|0|a¦b" "$(st)"
+printf 'n\n' | ./focus off >/dev/null 2>&1
+
+# A second 'on' with the same raw name must find the total the first one
+# logged under the sanitized name, not 0m under a key nothing was stored as.
+sqlite3 "$REFOCUS_DB_PATH" "UPDATE sessions SET duration_seconds=7200 WHERE project='a¦b';"
+out=$(printf 'n\n' | ./focus on 'a|b' 2>&1)
+chk "on '|' name: total-time lookup matches sanitized key" "0" \
+    "$([[ "$out" == *"120m logged"* ]]; echo $?)"
 
 # The bash-side guard is a friendly front door; the schema CHECK is the
 # actual backstop for anything that bypasses it (db_import_session_row is
@@ -284,6 +296,32 @@ chk "on '|' name leaves state idle" "0|0|0|-" "$(st)"
 sessions_before_check=$(cnt)
 bash -c 'source env.sh; source services/database.sh; db_import_session_row "bad|import" "" "" 3600 "" 0 "2026-06-11"' >/dev/null 2>&1
 chk "DB-level CHECK blocks '|' bypassing the bash guard" "$sessions_before_check" "$(cnt)"
+
+# A '|' in a NOTE must round-trip as the exact original byte, not get
+# transliterated (notes are free text; encode-on-read via _NOTES_ENCODED
+# preserves it, unlike project names which are short identifiers).
+printf 'Fixed the a|b parser bug\n' | ./focus past add note/pipe 2026/06/11-16:00 2026/06/11-17:00 >/dev/null 2>&1
+out=$(./focus past list 2>&1)
+chk "note with '|' round-trips exactly, not transliterated" "0" \
+    "$([[ "$out" == *"Fixed the a|b parser bug"* ]]; echo $?)"
+
+# JSON import: a '|' in one row's project must not abort the rest of the
+# import (the earlier bash-side rejection + schema CHECK both used to kill
+# the while-loop under set -e partway through; sanitizing at capture removes
+# the trigger, so every row after the bad one still lands).
+cat > "$SANDBOX/pipe-import.json" <<EOF
+{"sessions": [
+  {"project": "GoodOne", "start_time": "2026-06-11T10:00:00-03:00", "end_time": "2026-06-11T11:00:00-03:00", "duration_seconds": 3600, "notes": "", "duration_only": 0, "session_date": ""},
+  {"project": "bad|name", "start_time": "2026-06-11T12:00:00-03:00", "end_time": "2026-06-11T13:00:00-03:00", "duration_seconds": 3600, "notes": "", "duration_only": 0, "session_date": ""},
+  {"project": "GoodTwo", "start_time": "2026-06-11T14:00:00-03:00", "end_time": "2026-06-11T15:00:00-03:00", "duration_seconds": 3600, "notes": "", "duration_only": 0, "session_date": ""}
+]}
+EOF
+printf 'yes\n' | ./focus import "$SANDBOX/pipe-import.json" >/dev/null 2>&1
+chk "JSON import: '|' row doesn't abort the rest" "0" \
+    "$([[ "$(cnt)" -eq 3 ]]; echo $?)"
+chk "JSON import: bad row sanitized, not dropped" "1" \
+    "$(sqlite3 "$REFOCUS_DB_PATH" "SELECT COUNT(*) FROM sessions WHERE project='bad¦name';")"
+chk "JSON import: normalizes state per INV-5" "0|0|1|-" "$(st)"
 
 # ── result ───────────────────────────────────────────────────────────────────
 echo


### PR DESCRIPTION
Last round's CHECK constraint turned out to reintroduce the exact bug it was meant to prevent: a JSON import with '|' in one row's project name now aborted the whole import partway through under set -e (verified live — a 3-row file lost the row after the bad one entirely), and a partial SQL import skipped reset_state_post_import, leaving focus_disabled=0 (INV-5 violation).

Root fix: stop treating '|' as something to reject, and sanitize it at every input boundary instead, so the character that breaks the pipe-separated wire format never reaches storage in the first place — the CHECK constraint then never fires during normal use, since nothing malformed is ever written.

Two different mechanisms, because project names and notes have different needs:

- Project names (short identifiers): transliterate '|' -> '¦' (U+00A6). sanitize_pipe (renamed public, called across files) runs both at capture time in lib/on.sh and lib/past.sh's add case — not just at the final adapter write — so a total-time lookup or success message never disagrees with what's actually stored, and again inside the five adapter write functions as a second layer. Verified live: a second `focus on 'a|b'` correctly finds the total the first one logged under the sanitized name.
- Notes (free text): extend _NOTES_ENCODED to also escape '|' as \x7c, alongside the existing backslash/\n/\r handling — no change needed to notes_decode, printf %b already understands hex escapes. This preserves the exact byte a user typed rather than silently changing it, which matters for free text in a way it doesn't for a short identifier. Verified live: a note containing '|' round-trips through storage and display unchanged, not transliterated.
- lib/import.sh sanitizes the extracted project field before calling db_import_session_row, closing the JSON partial-import path. db_import_session_row itself stays unguarded on purpose (verbatim reconstruction) and the .sql import path relies on the CHECK alone — a blanket file-wide sed was considered and rejected: .sql exports embed the schema, and the CHECK constraint's own '|' literal (`instr(project, '|')`) would have been corrupted by it.

The CHECK constraint from last round is unchanged and still the backstop for anything that bypasses all of the above — verified live with every bash-side sanitization layer temporarily disabled, a raw '|' write still gets rejected at the SQL layer, 0 rows written.

tests/audit.sh: 0. tests/state-matrix.sh: 67/67 (was 62).
tests/time-portability.sh: 20/20.